### PR TITLE
Custom types support using specialization of StringConverter class

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Flags:
 ```
 
 ### Using custom types
-To use custom types in the config, it's necessary to overload `std::stringstream` `operator<<` and `operator>>`.  
+To use custom types in the config, it's necessary to add a specialization of the struct `cmdlime::StringConverter` and implement its static methods `toString` and `fromString`.   
 Let's add a coordinate parameter `--coord` to the `person-finder` program.
 
 ```C++
@@ -424,29 +424,34 @@ Let's add a coordinate parameter `--coord` to the `person-finder` program.
 ///
 #include <cmdlime/config.h>
 #include <iostream>
-#include <sstream>
 
 struct Coord{
     double lat;
     double lon;
 };
-std::stringstream& operator<<(std::stringstream& stream, const Coord& coord)
-{
-    stream << coord.lat << "-" << coord.lon;
-    return stream;
-}
-std::stringstream& operator>>(std::stringstream& stream, Coord& coord)
-{
-    auto coordStr = std::string{};
-    stream >> coordStr;
-    auto delimPos = coordStr.find('-');
-    if (delimPos == std::string::npos)
-        throw cmdlime::Error{"Wrong coord format"};
-    coord.lat = std::stod(coordStr.substr(0, delimPos));
-    coord.lon = std::stod(coordStr.substr(delimPos + 1, coordStr.size() - delimPos - 1));
-    return stream;
-}
 
+namespace cmdlime{
+template<>
+struct StringConverter<Coord>{
+    static std::optional<std::string> toString(const Coord& coord)
+    {
+        auto stream = std::stringstream{};
+        stream << coord.lat << "-" << coord.lon;
+        return stream.str();
+    }
+
+    static std::optional<Coord> fromString(const std::string& data)
+    {
+        auto delimPos = data.find('-');
+        if (delimPos == std::string::npos)
+            return {};
+        auto coord = Coord{};
+        coord.lat = std::stod(data.substr(0, delimPos));
+        coord.lon = std::stod(data.substr(delimPos + 1, data.size() - delimPos - 1));
+        return coord;
+    }
+};
+}
 
 int main(int argc, char** argv)
 {

--- a/examples/ex12.cpp
+++ b/examples/ex12.cpp
@@ -1,28 +1,33 @@
 #include <cmdlime/config.h>
 #include <iostream>
-#include <sstream>
 
 struct Coord{
     double lat;
     double lon;
 };
-std::stringstream& operator<<(std::stringstream& stream, const Coord& coord)
-{
-    stream << coord.lat << "-" << coord.lon;
-    return stream;
-}
-std::stringstream& operator>>(std::stringstream& stream, Coord& coord)
-{
-    auto coordStr = std::string{};
-    stream >> coordStr;
-    auto delimPos = coordStr.find('-');
-    if (delimPos == std::string::npos)
-        throw cmdlime::Error{"Wrong coord format"};
-    coord.lat = std::stod(coordStr.substr(0, delimPos));
-    coord.lon = std::stod(coordStr.substr(delimPos + 1, coordStr.size() - delimPos - 1));
-    return stream;
-}
 
+namespace cmdlime{
+template<>
+struct StringConverter<Coord>{
+    static std::optional<std::string> toString(const Coord& coord)
+    {
+        auto stream = std::stringstream{};
+        stream << coord.lat << "-" << coord.lon;
+        return stream.str();
+    }
+
+    static std::optional<Coord> fromString(const std::string& data)
+    {
+        auto delimPos = data.find('-');
+        if (delimPos == std::string::npos)
+            return {};
+        auto coord = Coord{};
+        coord.lat = std::stod(data.substr(0, delimPos));
+        coord.lon = std::stod(data.substr(delimPos + 1, data.size() - delimPos - 1));
+        return coord;
+    }
+};
+}
 
 int main(int argc, char** argv)
 {

--- a/include/cmdlime/detail/arg.h
+++ b/include/cmdlime/detail/arg.h
@@ -7,6 +7,7 @@
 #include <gsl/gsl>
 #include <cmdlime/errors.h>
 #include <cmdlime/customnames.h>
+#include <cmdlime/stringconverter.h>
 #include <sstream>
 #include <functional>
 #include <memory>
@@ -37,21 +38,17 @@ public:
 private:
     bool read(const std::string& data) override
     {
-        auto stream = std::stringstream{data};
-        return readFromStream(stream, argGetter_());
+        auto argVal = convertFromString<T>(data);
+        if (!argVal)
+            return false;
+        argGetter_() = *argVal;
+        return true;
     }
 
 private:
     OptionInfo info_;
     std::function<T&()> argGetter_;
 };
-
-template <>
-inline bool Arg<std::string>::read(const std::string& data)
-{
-    argGetter_() = data;
-    return true;
-}
 
 template<typename T, typename TConfig>
 class ArgCreator{

--- a/include/cmdlime/gnuconfig.h
+++ b/include/cmdlime/gnuconfig.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "customnames.h"
 #include "configreader.h"
+#include "stringconverter.h"
 #include "detail/config.h"
 #include "detail/configmacro.h"
 #include "detail/gnuformat.h"

--- a/include/cmdlime/posixconfig.h
+++ b/include/cmdlime/posixconfig.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "customnames.h"
 #include "configreader.h"
+#include "stringconverter.h"
 #include "detail/config.h"
 #include "detail/configmacro.h"
 #include "detail/posixformat.h"

--- a/include/cmdlime/simpleconfig.h
+++ b/include/cmdlime/simpleconfig.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "customnames.h"
 #include "configreader.h"
+#include "stringconverter.h"
 #include "detail/config.h"
 #include "detail/configmacro.h"
 #include "detail/simpleformat.h"

--- a/include/cmdlime/stringconverter.h
+++ b/include/cmdlime/stringconverter.h
@@ -1,0 +1,86 @@
+#pragma once
+#include <string>
+#include <sstream>
+#include <optional>
+
+namespace cmdlime{
+
+namespace detail {
+template<typename T, typename Enable = void>
+struct is_optional : std::false_type {};
+
+template<typename T>
+struct is_optional<std::optional<T> > : std::true_type {};
+}
+
+template<typename T>
+struct StringConverter{
+    static std::optional<std::string> toString(const T& value)
+    {
+        if constexpr(detail::is_optional<T>::value){
+            if (!value)
+                return {};
+            auto stream = std::stringstream{};
+            stream << *value;
+            return stream.str();
+        }
+        else {
+            auto stream = std::stringstream{};
+            stream << value;
+            return stream.str();
+        }
+    }
+
+    static std::optional<T> fromString(const std::string& data)
+    {
+        auto setValue = [](auto& value, const std::string& data) -> std::optional<T>
+        {
+            auto stream = std::stringstream{data};
+            stream >> value;
+
+            if (stream.bad() || stream.fail() || !stream.eof())
+                return {};
+            return value;
+        };
+
+        if constexpr(std::is_convertible_v<T, std::string>){
+            return data;
+        }
+        else if constexpr(detail::is_optional<T>::value){
+            auto value = T{};
+            value.emplace();
+            return setValue(*value, data);
+        }
+        else{
+            auto value = T{};
+            return setValue(value, data);
+        }
+    }
+};
+
+namespace detail {
+
+template<typename T>
+std::optional<std::string> convertToString(const T& value)
+{
+    try {
+        return StringConverter<T>::toString(value);
+    }
+    catch(...){
+        return {};
+    }
+}
+
+template<typename T>
+std::optional<T> convertFromString(const std::string& data)
+{
+    try {
+        return StringConverter<T>::fromString(data);
+    }
+    catch(...){
+        return {};
+    }
+}
+
+}
+}

--- a/include/cmdlime/x11config.h
+++ b/include/cmdlime/x11config.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "customnames.h"
 #include "configreader.h"
+#include "stringconverter.h"
 #include "detail/config.h"
 #include "detail/configmacro.h"
 #include "detail/x11format.h"


### PR DESCRIPTION
Now custom types are supported by adding a specialization of StringConverter class, instead of providing stream operators overloads. 