### PR TITLE
Added support of non-aggregate config types

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,60 @@
+---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
+AllowShortEnumsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterFunction: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  BeforeCatch: true
+BreakBeforeBraces: Custom
+BreakBeforeBinaryOperators: None
+BreakInheritanceList: AfterComma
+ColumnLimit: 120
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: true
+NamespaceIndentation: None
+PenaltyBreakBeforeFirstCallParameter: 0
+PenaltyReturnTypeOnItsOwnLine: 1000
+PenaltyBreakAssignment: 10
+SpaceBeforeCpp11BracedList: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpaceAfterTemplateKeyword: false
+SpacesInLineCommentPrefix:
+  Minimum: 0
+  Maximum: -1
+FixNamespaceComments: true
+UseCRLF: false
+IncludeCategories:
+  # Headers in <> without extension.
+  - Regex: '<[[:alnum:]\-_]+>'
+    Priority: 6
+  # Headers in <> from specific external libraries.
+  - Regex: '<(gtest|gmock|boost|gsl)\/'
+    Priority: 5
+  # Headers in <> with subdirectory.
+  - Regex: '<[[:alnum:]\-_]+\/'
+    Priority: 4
+  # Headers in <> with extension.
+  - Regex: '<[[:alnum:].\-_]+>'
+    Priority: 3
+  # Headers in "" with subdirectory.
+  - Regex: '"[[:alnum:]\-_]+\/'
+    Priority: 2
+  # Headers in "" with extension.
+  - Regex: '"[[:alnum:].\-_]+"'
+    Priority: 1
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 SealLake_Bundle(
         NAME cmdlime_sfun
         GIT_REPOSITORY https://github.com/kamchatka-volcano/sfun.git
-        GIT_TAG        v2.4.0
+        GIT_TAG        v3.0.0
         DESTINATION include/cmdlime/detail/external
         DIRECTORIES include/sfun
         TEXT_REPLACEMENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(cmdlime VERSION 2.1.1 DESCRIPTION "C++17 command line parsing library")
+project(cmdlime VERSION 2.2.0 DESCRIPTION "C++17 command line parsing library")
 include(GNUInstallDirs)
 include(external/seal_lake)
 

--- a/include/cmdlime/commandlinereader.h
+++ b/include/cmdlime/commandlinereader.h
@@ -277,9 +277,11 @@ private:
         clear();
         if constexpr (std::is_aggregate_v<TCfg>)
             return TCfg{{makePtr()}}; //can't add setCommandName and setUsageInfoFormat calls here
-                                  // due to the lack of NRVO on MSVC (the config object must not be copied)
-        else
+                                      // due to the lack of NRVO on MSVC (the config object must not be copied)
+        else{
+            static_assert(std::is_constructible_v<TCfg, detail::CommandLineReaderPtr>, "Non aggregate config objects must inherit cmdlime::Config constructors with 'using Config::Config;'");
             return TCfg{makePtr()};
+        }
     }
 
     void addDefaultFlags()

--- a/include/cmdlime/config.h
+++ b/include/cmdlime/config.h
@@ -2,32 +2,31 @@
 #define CMDLIME_CONFIG_H
 
 #include "customnames.h"
-#include "detail/configmacros.h"
-#include "detail/paramcreator.h"
-#include "detail/paramlistcreator.h"
-#include "detail/flagcreator.h"
 #include "detail/argcreator.h"
 #include "detail/arglistcreator.h"
 #include "detail/commandcreator.h"
+#include "detail/configmacros.h"
+#include "detail/flagcreator.h"
 #include "detail/icommandlinereader.h"
-#include "detail/nameof_import.h"
 #include "detail/ivalidator.h"
+#include "detail/nameof_import.h"
+#include "detail/paramcreator.h"
+#include "detail/paramlistcreator.h"
 #include <optional>
 #include <string>
 
-namespace cmdlime{
+namespace cmdlime {
 
 class Config {
 public:
     Config() = default;
     Config(detail::CommandLineReaderPtr reader)
         : reader_{reader}
-    {}
-    Config(const Config&) = default;
-    Config& operator=(const Config&) = default;
-    Config(Config&&)
     {
     }
+    Config(const Config&) = default;
+    Config& operator=(const Config&) = default;
+    Config(Config&&) {}
     Config& operator=(Config&&)
     {
         return *this;
@@ -155,16 +154,15 @@ protected:
 
 private:
 #ifdef CMDLIME_NAMEOF_AVAILABLE
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto param(T TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
         auto [memberName, memberTypeName] = detail::getMemberPtrNameAndType<member>(cfg);
         return detail::ParamCreator<T>{reader(), memberName, memberTypeName, cfg->*member};
-
     }
 
-    template <auto member, typename TParamList, typename TCfg>
+    template<auto member, typename TParamList, typename TCfg>
     auto paramList(TParamList TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
@@ -173,7 +171,7 @@ private:
         return detail::ParamListCreator<TParamList>{reader(), memberName, memberTypeName, cfg->*member};
     }
 
-    template <auto member, typename TCfg>
+    template<auto member, typename TCfg>
     auto flag(bool TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
@@ -181,7 +179,7 @@ private:
         return detail::FlagCreator{reader(), memberName, cfg->*member};
     }
 
-    template <auto member, typename TCfg>
+    template<auto member, typename TCfg>
     auto exitFlag(bool TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
@@ -189,7 +187,7 @@ private:
         return detail::FlagCreator{reader(), memberName, cfg->*member, detail::Flag::Type::Exit};
     }
 
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto arg(T TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
@@ -197,7 +195,7 @@ private:
         return detail::ArgCreator<T>{reader(), memberName, memberTypeName, cfg->*member};
     }
 
-    template <auto member, typename TArgList, typename TCfg>
+    template<auto member, typename TArgList, typename TCfg>
     auto argList(TArgList TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
@@ -206,7 +204,7 @@ private:
         return detail::ArgListCreator<TArgList>{reader(), memberName, memberTypeName, cfg->*member};
     }
 
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto command(detail::InitializedOptional<T> TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
@@ -214,7 +212,7 @@ private:
         return detail::CommandCreator<T>{reader(), memberName, cfg->*member};
     }
 
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto subCommand(detail::InitializedOptional<T> TCfg::*)
     {
         auto cfg = static_cast<TCfg*>(this);
@@ -223,63 +221,61 @@ private:
     }
 #endif
 
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto param(T TCfg::*, const std::string& memberName, const std::string& memberTypeName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::ParamCreator<T>{reader(), memberName, memberTypeName, cfg->*member};
     }
 
-    template <auto member, typename TParamList, typename TCfg>
+    template<auto member, typename TParamList, typename TCfg>
     auto paramList(TParamList TCfg::*, const std::string& memberName, const std::string& memberTypeName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::ParamListCreator<TParamList>{reader(), memberName, memberTypeName, cfg->*member};
     }
 
-    template <auto member, typename TCfg>
+    template<auto member, typename TCfg>
     auto flag(bool TCfg::*, const std::string& memberName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::FlagCreator{reader(), memberName, cfg->*member};
     }
 
-    template <auto member, typename TCfg>
+    template<auto member, typename TCfg>
     auto exitFlag(bool TCfg::*, const std::string& memberName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::FlagCreator{reader(), memberName, cfg->*member, detail::Flag::Type::Exit};
     }
 
-
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto arg(T TCfg::*, const std::string& memberName, const std::string& memberTypeName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::ArgCreator<T>{reader(), memberName, memberTypeName, cfg->*member};
     }
 
-    template <auto member, typename TArgList, typename TCfg>
+    template<auto member, typename TArgList, typename TCfg>
     auto argList(TArgList TCfg::*, const std::string& memberName, const std::string& memberTypeName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::ArgListCreator<TArgList>{reader(), memberName, memberTypeName, cfg->*member};
     }
 
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto command(detail::InitializedOptional<T> TCfg::*, const std::string& memberName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::CommandCreator<T>{reader(), memberName, cfg->*member};
     }
 
-    template <auto member, typename T, typename TCfg>
+    template<auto member, typename T, typename TCfg>
     auto subCommand(detail::InitializedOptional<T> TCfg::*, const std::string& memberName)
     {
         auto cfg = static_cast<TCfg*>(this);
         return detail::CommandCreator<T>{reader(), memberName, cfg->*member, detail::Command<T>::Type::SubCommand};
     }
-
 
 private:
     detail::CommandLineReaderPtr reader_;
@@ -289,6 +285,6 @@ private:
 template<typename T>
 using optional = std::conditional_t<std::is_base_of_v<Config, T>, detail::InitializedOptional<T>, std::optional<T>>;
 
-}
+} //namespace cmdlime
 
 #endif //CMDLIME_CONFIG_H

--- a/include/cmdlime/customnames.h
+++ b/include/cmdlime/customnames.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <utility>
 
-namespace cmdlime{
+namespace cmdlime {
 
 namespace detail {
 enum class CustomNameType {
@@ -13,15 +13,15 @@ enum class CustomNameType {
     ShortName,
     ValueName
 };
-}
+} //namespace detail
 
-template <detail::CustomNameType>
-class CustomName{
+template<detail::CustomNameType>
+class CustomName {
 public:
     CustomName(std::string name)
         : value_(std::move(name))
     {
-        if(value_.empty())
+        if (value_.empty())
             throw ConfigError{"Custom name can't be empty."};
     }
 
@@ -37,8 +37,8 @@ private:
 using Name = CustomName<detail::CustomNameType::Name>;
 using ShortName = CustomName<detail::CustomNameType::ShortName>;
 using ValueName = CustomName<detail::CustomNameType::ValueName>;
-struct WithoutShortName{};
+struct WithoutShortName {};
 
-}
+} //namespace cmdlime
 
 #endif //CMDLIME_CUSTOMNAMES_H

--- a/include/cmdlime/detail/arg.h
+++ b/include/cmdlime/detail/arg.h
@@ -3,21 +3,19 @@
 
 #include "iarg.h"
 #include "optioninfo.h"
-#include <cmdlime/errors.h>
 #include <cmdlime/customnames.h>
+#include <cmdlime/errors.h>
 #include <cmdlime/stringconverter.h>
-#include <sstream>
 #include <functional>
 #include <memory>
+#include <sstream>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <typename T>
-class Arg : public IArg{
+template<typename T>
+class Arg : public IArg {
 public:
-    Arg(std::string name,
-        std::string type,
-        T& argValue)
+    Arg(std::string name, std::string type, T& argValue)
         : info_(std::move(name), {}, std::move(type))
         , argValue_(argValue)
     {
@@ -53,6 +51,6 @@ private:
     T& argValue_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_ARG_H

--- a/include/cmdlime/detail/argcreator.h
+++ b/include/cmdlime/detail/argcreator.h
@@ -7,17 +7,14 @@
 #include "validator.h"
 #include "external/sfun/contract.h"
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 template<typename T>
-class ArgCreator{
+class ArgCreator {
 public:
-    ArgCreator(CommandLineReaderPtr reader,
-               const std::string& varName,
-               const std::string& type,
-               T& argValue)
-            : reader_(reader)
-            , argValue_(argValue)
+    ArgCreator(CommandLineReaderPtr reader, const std::string& varName, const std::string& type, T& argValue)
+        : reader_(reader)
+        , argValue_(argValue)
     {
         sfunPrecondition(!varName.empty());
         sfunPrecondition(!type.empty());
@@ -65,6 +62,6 @@ private:
     T& argValue_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_ARGCREATOR_H

--- a/include/cmdlime/detail/argcreator.h
+++ b/include/cmdlime/detail/argcreator.h
@@ -5,7 +5,8 @@
 #include "icommandlinereader.h"
 #include "nameformat.h"
 #include "validator.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
+
 namespace cmdlime::detail{
 
 template<typename T>

--- a/include/cmdlime/detail/arglist.h
+++ b/include/cmdlime/detail/arglist.h
@@ -3,22 +3,20 @@
 
 #include "iarglist.h"
 #include "optioninfo.h"
-#include <cmdlime/errors.h>
 #include <cmdlime/customnames.h>
+#include <cmdlime/errors.h>
 #include <cmdlime/stringconverter.h>
-#include <vector>
-#include <sstream>
 #include <functional>
 #include <memory>
+#include <sstream>
+#include <vector>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <typename TArgList>
-class ArgList : public IArgList{
+template<typename TArgList>
+class ArgList : public IArgList {
 public:
-    ArgList(std::string name,
-            std::string type,
-            TArgList& argListValue)
+    ArgList(std::string name, std::string type, TArgList& argListValue)
         : info_(std::move(name), {}, std::move(type))
         , argListValue_(argListValue)
     {
@@ -48,7 +46,7 @@ public:
 private:
     bool read(const std::string& data) override
     {
-        if (!isDefaultValueOverwritten_){
+        if (!isDefaultValueOverwritten_) {
             argListValue_.clear();
             isDefaultValueOverwritten_ = true;
         }
@@ -77,7 +75,7 @@ private:
         auto stream = std::stringstream{};
         stream << "{";
         auto firstVal = true;
-        for (auto& val : *defaultValue_){
+        for (auto& val : *defaultValue_) {
             if (firstVal)
                 stream << ", ";
             firstVal = false;
@@ -98,6 +96,6 @@ private:
     bool isDefaultValueOverwritten_ = false;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_ARGLIST_H

--- a/include/cmdlime/detail/arglistcreator.h
+++ b/include/cmdlime/detail/arglistcreator.h
@@ -5,22 +5,23 @@
 #include "icommandlinereader.h"
 #include "nameformat.h"
 #include "validator.h"
-#include "external/sfun/type_traits.h"
 #include "external/sfun/contract.h"
+#include "external/sfun/type_traits.h"
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 template<typename TArgList>
-class ArgListCreator{
+class ArgListCreator {
     static_assert(sfun::is_dynamic_sequence_container_v<TArgList>, "Argument list field must be a sequence container");
 
 public:
-    ArgListCreator(CommandLineReaderPtr reader,
-                   const std::string& varName,
-                   const std::string& type,
-                   TArgList& argListValue)
-            : reader_(reader)
-            , argListValue_(argListValue)
+    ArgListCreator(
+            CommandLineReaderPtr reader,
+            const std::string& varName,
+            const std::string& type,
+            TArgList& argListValue)
+        : reader_(reader)
+        , argListValue_(argListValue)
     {
         sfunPrecondition(!varName.empty());
         sfunPrecondition(!type.empty());
@@ -48,10 +49,11 @@ public:
         return *this;
     }
 
-    auto& operator <<(std::function<void(const TArgList&)> validationFunc)
+    auto& operator<<(std::function<void(const TArgList&)> validationFunc)
     {
         if (reader_)
-            reader_->addValidator(std::make_unique<Validator<TArgList>>(*argList_, argListValue_, std::move(validationFunc)));
+            reader_->addValidator(
+                    std::make_unique<Validator<TArgList>>(*argList_, argListValue_, std::move(validationFunc)));
         return *this;
     }
 
@@ -76,5 +78,5 @@ private:
     TArgList& argListValue_;
 };
 
-}
+} //namespace cmdlime::detail
 #endif //CMDLIME_ARGLISTCREATOR_H

--- a/include/cmdlime/detail/arglistcreator.h
+++ b/include/cmdlime/detail/arglistcreator.h
@@ -5,14 +5,14 @@
 #include "icommandlinereader.h"
 #include "nameformat.h"
 #include "validator.h"
-#include "external/sfun/traits.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/type_traits.h"
+#include "external/sfun/contract.h"
 
 namespace cmdlime::detail{
 
 template<typename TArgList>
 class ArgListCreator{
-    static_assert(is_dynamic_sequence_container_v<TArgList>, "Argument list field must be a sequence container");
+    static_assert(sfun::is_dynamic_sequence_container_v<TArgList>, "Argument list field must be a sequence container");
 
 public:
     ArgListCreator(CommandLineReaderPtr reader,

--- a/include/cmdlime/detail/command.h
+++ b/include/cmdlime/detail/command.h
@@ -1,34 +1,31 @@
 #ifndef CMDLIME_COMMAND_H
 #define CMDLIME_COMMAND_H
 
-#include "icommand.h"
-#include "optioninfo.h"
 #include "flag.h"
+#include "icommand.h"
 #include "icommandlinereader.h"
-#include "options.h"
-#include "nameformat.h"
 #include "initializedoptional.h"
-#include <cmdlime/errors.h>
+#include "nameformat.h"
+#include "optioninfo.h"
+#include "options.h"
 #include <cmdlime/customnames.h>
+#include <cmdlime/errors.h>
 #include <cmdlime/usageinfoformat.h>
-#include <sstream>
 #include <functional>
 #include <memory>
+#include <sstream>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <typename TConfig>
-class Command : public ICommand{
+template<typename TConfig>
+class Command : public ICommand {
 public:
-    enum class Type{
+    enum class Type {
         Normal,
         SubCommand
     };
 
-    Command(const std::string& name,
-            InitializedOptional<TConfig>& commandCfg,
-            CommandLineReaderPtr reader,
-            Type type)
+    Command(const std::string& name, InitializedOptional<TConfig>& commandCfg, CommandLineReaderPtr reader, Type type)
         : info_(name, {}, {})
         , type_(type)
         , cfg_(commandCfg)
@@ -60,7 +57,7 @@ private:
 
         reader_->setCommandName(commandName_);
         reader_->setUsageInfoFormat(commandUsageInfoFormat_);
-        if (helpFlag_){
+        if (helpFlag_) {
             reader_->addFlag(std::move(helpFlag_));
             for (auto& command : reader_->options().commands())
                 command->enableHelpFlag();
@@ -76,10 +73,11 @@ private:
 
     void enableHelpFlag() override
     {
-        helpFlag_ = std::make_unique<detail::Flag>(NameFormat::name(reader_->format(), "help"),
-                                                   std::string{},
-                                                   helpFlagValue_,
-                                                   detail::Flag::Type::Exit);
+        helpFlag_ = std::make_unique<detail::Flag>(
+                NameFormat::name(reader_->format(), "help"),
+                std::string{},
+                helpFlagValue_,
+                detail::Flag::Type::Exit);
         helpFlag_->info().addDescription("show usage info and exit");
     }
 
@@ -119,8 +117,7 @@ private:
 
     void setCommandName(const std::string& parentCommandName) override
     {
-        commandName_ = parentCommandName.empty() ? info_.name() :
-                       parentCommandName + " " + info_.name();
+        commandName_ = parentCommandName.empty() ? info_.name() : parentCommandName + " " + info_.name();
     }
 
     void validate() const override
@@ -128,7 +125,6 @@ private:
         if (reader_ && cfg_)
             reader_->validate(info_.name());
     }
-
 
 private:
     OptionInfo info_;
@@ -141,6 +137,6 @@ private:
     bool helpFlagValue_ = false;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_COMMAND_H

--- a/include/cmdlime/detail/commandcreator.h
+++ b/include/cmdlime/detail/commandcreator.h
@@ -6,7 +6,7 @@
 #include "nameformat.h"
 #include "validator.h"
 #include "initializedoptional.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 
 namespace cmdlime{
 class Config;

--- a/include/cmdlime/detail/commandcreator.h
+++ b/include/cmdlime/detail/commandcreator.h
@@ -61,6 +61,8 @@ public:
     {
         if (reader_)
             reader_->addCommand(std::move(command_));
+        if constexpr(!std::is_aggregate_v<TCfg>)
+            static_assert(std::is_constructible_v<TCfg, detail::CommandLineReaderPtr>, "Non aggregate config objects must inherit cmdlime::Config constructors with 'using Config::Config;'");
         return InitializedOptional<TCfg>{nestedReader_};
     }
 

--- a/include/cmdlime/detail/commandcreator.h
+++ b/include/cmdlime/detail/commandcreator.h
@@ -3,31 +3,33 @@
 
 #include "command.h"
 #include "icommandlinereader.h"
+#include "initializedoptional.h"
 #include "nameformat.h"
 #include "validator.h"
-#include "initializedoptional.h"
 #include "external/sfun/contract.h"
 
-namespace cmdlime{
+namespace cmdlime {
 class Config;
 }
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 template<typename TCfg>
-class CommandCreator{
-    static_assert(std::is_base_of_v<Config, TCfg>,
-                  "TCfg must be a subclass of cmdlime::Config.");
+class CommandCreator {
+    static_assert(std::is_base_of_v<Config, TCfg>, "TCfg must be a subclass of cmdlime::Config.");
+
 public:
-    CommandCreator(CommandLineReaderPtr reader,
-                   const std::string& varName,
-                   InitializedOptional<TCfg>& commandValue,
-                   typename Command<TCfg>::Type type = Command<TCfg>::Type::Normal)
-            : reader_(reader)
-            , commandValue_(commandValue)
+    CommandCreator(
+            CommandLineReaderPtr reader,
+            const std::string& varName,
+            InitializedOptional<TCfg>& commandValue,
+            typename Command<TCfg>::Type type = Command<TCfg>::Type::Normal)
+        : reader_(reader)
+        , commandValue_(commandValue)
     {
         sfunPrecondition(!varName.empty());
-        nestedReader_ = reader_ ? reader_->makeNestedReader(NameFormat::fullName(reader_->format(), varName)) : CommandLineReaderPtr{};
+        nestedReader_ = reader_ ? reader_->makeNestedReader(NameFormat::fullName(reader_->format(), varName))
+                                : CommandLineReaderPtr{};
         command_ = std::make_unique<Command<TCfg>>(
                 reader_ ? NameFormat::fullName(reader->format(), varName) : varName,
                 commandValue,
@@ -61,8 +63,11 @@ public:
     {
         if (reader_)
             reader_->addCommand(std::move(command_));
-        if constexpr(!std::is_aggregate_v<TCfg>)
-            static_assert(std::is_constructible_v<TCfg, detail::CommandLineReaderPtr>, "Non aggregate config objects must inherit cmdlime::Config constructors with 'using Config::Config;'");
+        if constexpr (!std::is_aggregate_v<TCfg>)
+            static_assert(
+                    std::is_constructible_v<TCfg, detail::CommandLineReaderPtr>,
+                    "Non aggregate config objects must inherit cmdlime::Config constructors with 'using "
+                    "Config::Config;'");
         return InitializedOptional<TCfg>{nestedReader_};
     }
 
@@ -73,6 +78,6 @@ private:
     InitializedOptional<TCfg>& commandValue_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_COMMANDCREATOR_H

--- a/include/cmdlime/detail/commandlinereaderptr.h
+++ b/include/cmdlime/detail/commandlinereaderptr.h
@@ -4,14 +4,14 @@
 namespace cmdlime::detail {
 class ICommandLineReader;
 
-
 class CommandLineReaderPtr {
     friend class ICommandLineReader;
 
 private:
     CommandLineReaderPtr(ICommandLineReader* reader)
         : reader_{reader}
-    {}
+    {
+    }
 
 public:
     CommandLineReaderPtr() = default;
@@ -45,6 +45,6 @@ private:
     ICommandLineReader* reader_ = nullptr;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_COMMANDLINEREADERPTR_H

--- a/include/cmdlime/detail/configmacros.h
+++ b/include/cmdlime/detail/configmacros.h
@@ -13,10 +13,4 @@
 #define CMDLIME_COMMAND(name, type) cmdlime::detail::InitializedOptional<type> name = command<&std::remove_pointer_t<decltype(this)>::name>(#name)
 #define CMDLIME_SUBCOMMAND(name, type) cmdlime::detail::InitializedOptional<type> name = subCommand<&std::remove_pointer_t<decltype(this)>::name>(#name)
 
-#define CMDLIME_INIT(Cfg) \
-Cfg() = default; \
-Cfg(detail::CommandLineReaderPtr readerPtr) \
-    : cmdlime::Config(readerPtr) \
-{}
-
 #endif //CMDLIME_CONFIGMACROS_H

--- a/include/cmdlime/detail/configmacros.h
+++ b/include/cmdlime/detail/configmacros.h
@@ -1,8 +1,8 @@
 #ifndef CMDLIME_CONFIGMACROS_H
 #define CMDLIME_CONFIGMACROS_H
 
-#include <vector>
 #include <optional>
+#include <vector>
 
 #define CMDLIME_PARAM(name, type) type name = param<&std::remove_pointer_t<decltype(this)>::name>(#name, #type)
 #define CMDLIME_PARAMLIST(name, type) type name = paramList<&std::remove_pointer_t<decltype(this)>::name>(#name, #type)
@@ -10,7 +10,9 @@
 #define CMDLIME_EXITFLAG(name) bool name = exitFlag<&std::remove_pointer_t<decltype(this)>::name>(#name)
 #define CMDLIME_ARG(name, type) type name = arg<&std::remove_pointer_t<decltype(this)>::name>(#name, #type)
 #define CMDLIME_ARGLIST(name, type) type name = argList<&std::remove_pointer_t<decltype(this)>::name>(#name, #type)
-#define CMDLIME_COMMAND(name, type) cmdlime::detail::InitializedOptional<type> name = command<&std::remove_pointer_t<decltype(this)>::name>(#name)
-#define CMDLIME_SUBCOMMAND(name, type) cmdlime::detail::InitializedOptional<type> name = subCommand<&std::remove_pointer_t<decltype(this)>::name>(#name)
+#define CMDLIME_COMMAND(name, type)                                                                                    \
+    cmdlime::detail::InitializedOptional<type> name = command<&std::remove_pointer_t<decltype(this)>::name>(#name)
+#define CMDLIME_SUBCOMMAND(name, type)                                                                                 \
+    cmdlime::detail::InitializedOptional<type> name = subCommand<&std::remove_pointer_t<decltype(this)>::name>(#name)
 
 #endif //CMDLIME_CONFIGMACROS_H

--- a/include/cmdlime/detail/flag.h
+++ b/include/cmdlime/detail/flag.h
@@ -4,23 +4,20 @@
 #include "iflag.h"
 #include "optioninfo.h"
 #include <cmdlime/customnames.h>
-#include <memory>
 #include <functional>
+#include <memory>
 #include <utility>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-class Flag : public IFlag{
+class Flag : public IFlag {
 public:
-    enum class Type{
+    enum class Type {
         Normal,
         Exit
     };
 
-    Flag(std::string name,
-         std::string shortName,
-         bool& flagValue,
-         Type type)
+    Flag(std::string name, std::string shortName, bool& flagValue, Type type)
         : info_(std::move(name), std::move(shortName), {})
         , flagValue_(flagValue)
         , type_(type)
@@ -64,7 +61,6 @@ private:
     Type type_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_FLAG_H
-

--- a/include/cmdlime/detail/flagcreator.h
+++ b/include/cmdlime/detail/flagcreator.h
@@ -5,7 +5,7 @@
 #include "icommandlinereader.h"
 #include "nameformat.h"
 #include "validator.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 
 namespace cmdlime::detail{
 

--- a/include/cmdlime/detail/flagcreator.h
+++ b/include/cmdlime/detail/flagcreator.h
@@ -7,15 +7,16 @@
 #include "validator.h"
 #include "external/sfun/contract.h"
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-class FlagCreator{
+class FlagCreator {
 
 public:
-    FlagCreator(CommandLineReaderPtr reader,
-                const std::string& varName,
-                bool& flagValue,
-                Flag::Type flagType = Flag::Type::Normal)
+    FlagCreator(
+            CommandLineReaderPtr reader,
+            const std::string& varName,
+            bool& flagValue,
+            Flag::Type flagType = Flag::Type::Normal)
         : reader_(reader)
     {
         sfunPrecondition(!varName.empty());
@@ -64,6 +65,6 @@ private:
     CommandLineReaderPtr reader_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_FLAGCREATOR_H

--- a/include/cmdlime/detail/formatcfg.h
+++ b/include/cmdlime/detail/formatcfg.h
@@ -3,7 +3,7 @@
 
 #include <cmdlime/format.h>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 template<Format>
 struct FormatCfg;
@@ -20,6 +20,6 @@ struct FormatCfg<Format::X11>;
 template<>
 struct FormatCfg<Format::GNU>;
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_FORMATCFG_H

--- a/include/cmdlime/detail/gnuformat.h
+++ b/include/cmdlime/detail/gnuformat.h
@@ -1,24 +1,23 @@
 #ifndef CMDLIME_GNUFORMAT_H
 #define CMDLIME_GNUFORMAT_H
 
-#include "parser.h"
-#include "nameutils.h"
-#include "utils.h"
 #include "formatcfg.h"
-#include <cmdlime/errors.h>
-#include "external/sfun/string_utils.h"
+#include "nameutils.h"
+#include "parser.h"
+#include "utils.h"
 #include "external/sfun/contract.h"
+#include "external/sfun/string_utils.h"
+#include <cmdlime/errors.h>
 #include <algorithm>
-#include <sstream>
-#include <iomanip>
 #include <functional>
+#include <iomanip>
 #include <optional>
+#include <sstream>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <Format formatType>
-class GNUParser : public Parser<formatType>
-{
+template<Format formatType>
+class GNUParser : public Parser<formatType> {
     using Parser<formatType>::Parser;
     using FindMode = typename Parser<formatType>::FindMode;
 
@@ -31,7 +30,7 @@ class GNUParser : public Parser<formatType>
 
     void process(const std::string& token) override
     {
-        if (!foundParam_.empty()){
+        if (!foundParam_.empty()) {
             this->readParam(foundParam_, token);
             foundParam_.clear();
         }
@@ -53,18 +52,17 @@ class GNUParser : public Parser<formatType>
     {
         auto command = sfun::after(commandStr, "--");
         auto paramValue = std::optional<std::string>{};
-        if (command.find('=') != std::string::npos){
+        if (command.find('=') != std::string::npos) {
             paramValue = sfun::after(command, "=");
             command = sfun::before(command, "=");
         }
-        if (isParamOrFlag(command) &&
-            !foundParam_.empty() &&
+        if (isParamOrFlag(command) && !foundParam_.empty() &&
             this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands)
             throw ParsingError{"Parameter '" + foundParamPrefix_ + foundParam_ + "' value can't be empty"};
-        if (this->findParam(command, FindMode::Name) || this->findParamList(command, FindMode::Name)){
+        if (this->findParam(command, FindMode::Name) || this->findParamList(command, FindMode::Name)) {
             if (paramValue.has_value())
                 this->readParam(command, paramValue.value());
-            else{
+            else {
                 foundParam_ = command;
                 foundParamPrefix_ = "--";
             }
@@ -79,7 +77,7 @@ class GNUParser : public Parser<formatType>
     {
         auto possibleNumberArg = command;
         command = sfun::after(command, "-");
-        if (isShortParamOrFlag(command)){
+        if (isShortParamOrFlag(command)) {
             if (!foundParam_.empty() && this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands)
                 throw ParsingError{"Parameter '" + foundParamPrefix_ + foundParam_ + "' value can't be empty"};
             parseShortCommand(command);
@@ -95,24 +93,24 @@ class GNUParser : public Parser<formatType>
         if (command.empty())
             throw ParsingError{"Flags and parameters must have a name"};
         auto paramValue = std::string{};
-        for(auto ch : command){
+        for (auto ch : command) {
             auto opt = std::string{ch};
             if (!foundParam_.empty())
                 paramValue += opt;
             else if (this->findFlag(opt, FindMode::ShortName))
                 this->readFlag(opt);
-            else if (this->findParam(opt, FindMode::ShortName)){
+            else if (this->findParam(opt, FindMode::ShortName)) {
                 foundParam_ = opt;
                 foundParamPrefix_ = "-";
             }
-            else if (this->findParamList(opt, FindMode::ShortName)){
+            else if (this->findParamList(opt, FindMode::ShortName)) {
                 foundParam_ = opt;
                 foundParamPrefix_ = "-";
             }
             else if (this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands)
                 throw ParsingError{"Unknown option '" + opt + "' in command '-" + command + "'"};
         }
-        if (!foundParam_.empty() && !paramValue.empty()){
+        if (!foundParam_.empty() && !paramValue.empty()) {
             this->readParam(foundParam_, paramValue);
             foundParam_.clear();
         }
@@ -120,45 +118,68 @@ class GNUParser : public Parser<formatType>
 
     void checkLongNames()
     {
-        auto check = [](const OptionInfo& var, const std::string& varType){
+        auto check = [](const OptionInfo& var, const std::string& varType)
+        {
             if (!std::isalpha(var.name().front()))
                 throw ConfigError{varType + "'s name '" + var.name() + "' must start with an alphabet character"};
-            if (var.name().size() > 1){
-                auto nonSupportedCharIt = std::find_if(var.name().begin() + 1, var.name().end(), [](char ch){return !std::isalnum(ch) && ch != '-';});
+            if (var.name().size() > 1) {
+                auto nonSupportedCharIt = std::find_if(
+                        var.name().begin() + 1,
+                        var.name().end(),
+                        [](char ch)
+                        {
+                            return !std::isalnum(ch) && ch != '-';
+                        });
                 if (nonSupportedCharIt != var.name().end())
-                    throw ConfigError{varType + "'s name '" + var.name() + "' must consist of alphanumeric characters and hyphens"};
+                    throw ConfigError{
+                            varType + "'s name '" + var.name() +
+                            "' must consist of alphanumeric characters and hyphens"};
             }
         };
-        this->forEachParamInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachParamListInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachFlagInfo([check](const OptionInfo& var){
-            check(var, "Flag");
-        });
+        this->forEachParamInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachParamListInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachFlagInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Flag");
+                });
     }
 
     void checkShortNames()
     {
-        auto check = [](const OptionInfo& var, const std::string& varType){
+        auto check = [](const OptionInfo& var, const std::string& varType)
+        {
             if (var.shortName().empty())
                 return;
             if (var.shortName().size() != 1)
                 throw ConfigError{varType + "'s short name '" + var.shortName() + "' can't have more than one symbol"};
             if (!std::isalnum(var.shortName().front()))
-                throw ConfigError{varType + "'s short name '" + var.shortName() + "' must be an alphanumeric character"};
+                throw ConfigError{
+                        varType + "'s short name '" + var.shortName() + "' must be an alphanumeric character"};
         };
-        this->forEachParamInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachParamListInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachFlagInfo([check](const OptionInfo& var){
-            check(var, "Flag");
-        });
+        this->forEachParamInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachParamListInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachFlagInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Flag");
+                });
     }
 
     void checkNames()
@@ -171,19 +192,17 @@ class GNUParser : public Parser<formatType>
     {
         if (str.empty())
             return false;
-        return this->findFlag(str, FindMode::Name) ||
-               this->findParam(str, FindMode::Name) ||
-               this->findParamList(str, FindMode::Name);
+        return this->findFlag(str, FindMode::Name) || this->findParam(str, FindMode::Name) ||
+                this->findParamList(str, FindMode::Name);
     }
 
     bool isShortParamOrFlag(const std::string& str)
     {
         if (str.empty())
             return false;
-        auto opt = str.substr(0,1);
-        return this->findFlag(opt, FindMode::ShortName) ||
-               this->findParam(opt, FindMode::ShortName) ||
-               this->findParamList(opt, FindMode::ShortName);
+        auto opt = str.substr(0, 1);
+        return this->findFlag(opt, FindMode::ShortName) || this->findParam(opt, FindMode::ShortName) ||
+                this->findParamList(opt, FindMode::ShortName);
     }
 
 private:
@@ -191,7 +210,7 @@ private:
     std::string foundParamPrefix_;
 };
 
-class GNUNameProvider{
+class GNUNameProvider {
 public:
     static std::string name(const std::string& optionName)
     {
@@ -218,8 +237,7 @@ public:
     }
 };
 
-
-class GNUOutputFormatter{
+class GNUOutputFormatter {
 public:
     static std::string paramUsageName(const IParam& param)
     {
@@ -248,7 +266,8 @@ public:
         if (!param.info().shortName().empty())
             stream << "-" << param.info().shortName() << ", ";
         else
-            stream << " " << "   ";
+            stream << " "
+                   << "   ";
         stream << "--" << param.info().name() << " <" << param.info().valueName() << ">";
         return stream.str();
     }
@@ -260,7 +279,8 @@ public:
         if (!param.info().shortName().empty())
             stream << "-" << param.info().shortName() << ", ";
         else
-            stream << " " << "   ";
+            stream << " "
+                   << "   ";
         stream << "--" << param.info().name() << " <" << param.info().valueName() << ">";
         return stream.str();
     }
@@ -280,11 +300,12 @@ public:
     static std::string flagDescriptionName(const IFlag& flag, int indent = 0)
     {
         auto stream = std::stringstream{};
-        stream << std::setw(indent) ;
+        stream << std::setw(indent);
         if (!flag.info().shortName().empty())
             stream << "-" << flag.info().shortName() << ", ";
         else
-            stream << " " << "   ";
+            stream << " "
+                   << "   ";
         stream << "--" << flag.info().name();
         return stream.str();
     }
@@ -328,18 +349,16 @@ public:
         stream << "<" << argList.info().name() << "> (" << argList.info().valueName() << ")";
         return stream.str();
     }
-
 };
 
 template<>
-struct FormatCfg<Format::GNU>
-{
+struct FormatCfg<Format::GNU> {
     using parser = GNUParser<Format::GNU>;
     using nameProvider = GNUNameProvider;
     using outputFormatter = GNUOutputFormatter;
     static constexpr bool shortNamesEnabled = true;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_GNUFORMAT_H

--- a/include/cmdlime/detail/gnuformat.h
+++ b/include/cmdlime/detail/gnuformat.h
@@ -7,7 +7,7 @@
 #include "formatcfg.h"
 #include <cmdlime/errors.h>
 #include "external/sfun/string_utils.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
@@ -15,7 +15,6 @@
 #include <optional>
 
 namespace cmdlime::detail{
-namespace str = sfun::string_utils;
 
 template <Format formatType>
 class GNUParser : public Parser<formatType>
@@ -36,9 +35,9 @@ class GNUParser : public Parser<formatType>
             this->readParam(foundParam_, token);
             foundParam_.clear();
         }
-        else if (str::startsWith(token, "--") && token.size() > 2)
+        else if (sfun::startsWith(token, "--") && token.size() > 2)
             processCommand(token);
-        else if (str::startsWith(token, "-") && token.size() > 1)
+        else if (sfun::startsWith(token, "-") && token.size() > 1)
             processShortCommand(token);
         else
             this->readArg(token);
@@ -52,11 +51,11 @@ class GNUParser : public Parser<formatType>
 
     void processCommand(const std::string& commandStr)
     {
-        auto command = str::after(commandStr, "--");
+        auto command = sfun::after(commandStr, "--");
         auto paramValue = std::optional<std::string>{};
         if (command.find('=') != std::string::npos){
-            paramValue = str::after(command, "=");
-            command = str::before(command, "=");
+            paramValue = sfun::after(command, "=");
+            command = sfun::before(command, "=");
         }
         if (isParamOrFlag(command) &&
             !foundParam_.empty() &&
@@ -79,7 +78,7 @@ class GNUParser : public Parser<formatType>
     void processShortCommand(std::string command)
     {
         auto possibleNumberArg = command;
-        command = str::after(command, "-");
+        command = sfun::after(command, "-");
         if (isShortParamOrFlag(command)){
             if (!foundParam_.empty() && this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands)
                 throw ParsingError{"Parameter '" + foundParamPrefix_ + foundParam_ + "' value can't be empty"};

--- a/include/cmdlime/detail/iarg.h
+++ b/include/cmdlime/detail/iarg.h
@@ -4,13 +4,13 @@
 #include "ioption.h"
 #include <string>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-class IArg : public IOption{
+class IArg : public IOption {
 public:
-    virtual bool read(const std::string& data)  = 0;
+    virtual bool read(const std::string& data) = 0;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_IARG_H

--- a/include/cmdlime/detail/iarglist.h
+++ b/include/cmdlime/detail/iarglist.h
@@ -4,17 +4,17 @@
 #include "ioption.h"
 #include <string>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 class OptionInfo;
 
-class IArgList : public IOption{
+class IArgList : public IOption {
 public:
-    virtual bool read(const std::string& data)  = 0;
+    virtual bool read(const std::string& data) = 0;
     virtual bool hasValue() const = 0;
     virtual bool isOptional() const = 0;
     virtual std::string defaultValue() const = 0;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_IARGLIST_H

--- a/include/cmdlime/detail/icommand.h
+++ b/include/cmdlime/detail/icommand.h
@@ -1,18 +1,18 @@
 #ifndef CMDLIME_ICOMMAND_H
 #define CMDLIME_ICOMMAND_H
 
-#include "ioption.h"
 #include "icommandlinereader.h"
-#include <vector>
-#include <string>
+#include "ioption.h"
 #include <memory>
+#include <string>
+#include <vector>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 class OptionInfo;
 class IFlag;
 class IConfig;
 
-class ICommand : public IOption{
+class ICommand : public IOption {
 public:
     virtual bool hasValue() const = 0;
     virtual CommandLineReaderPtr configReader() const = 0;
@@ -27,6 +27,6 @@ public:
     virtual void validate() const = 0;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_ICOMMAND_H

--- a/include/cmdlime/detail/icommandlinereader.h
+++ b/include/cmdlime/detail/icommandlinereader.h
@@ -2,6 +2,7 @@
 #define CMDLIME_ICOMMANDLINEREADER_H
 
 #include "commandlinereaderptr.h"
+#include "external/sfun/interface.h"
 #include <cmdlime/format.h>
 #include <vector>
 #include <string>
@@ -26,15 +27,8 @@ enum CommandLineReadResult{
     StoppedOnExitFlag
 };
 
-class ICommandLineReader{
+class ICommandLineReader : private sfun::Interface<ICommandLineReader>{
 public:
-    ICommandLineReader() = default;
-    virtual ~ICommandLineReader() = default;
-    ICommandLineReader(const ICommandLineReader&) = delete;
-    ICommandLineReader& operator=(const ICommandLineReader&) = delete;
-    ICommandLineReader(ICommandLineReader&&) = delete;
-    ICommandLineReader& operator=(ICommandLineReader&&) = delete;
-
     virtual CommandLineReadResult read(const std::vector<std::string>& cmdLine) = 0;
     virtual const std::string& versionInfo() const = 0;
     virtual std::string usageInfo() const = 0;

--- a/include/cmdlime/detail/icommandlinereader.h
+++ b/include/cmdlime/detail/icommandlinereader.h
@@ -4,15 +4,15 @@
 #include "commandlinereaderptr.h"
 #include "external/sfun/interface.h"
 #include <cmdlime/format.h>
-#include <vector>
-#include <string>
 #include <memory>
+#include <string>
+#include <vector>
 
-namespace cmdlime{
+namespace cmdlime {
 struct UsageInfoFormat;
 }
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 class Options;
 class IParam;
 class IParamList;
@@ -22,12 +22,12 @@ class IArgList;
 class ICommand;
 class IValidator;
 
-enum CommandLineReadResult{
+enum CommandLineReadResult {
     Completed,
     StoppedOnExitFlag
 };
 
-class ICommandLineReader : private sfun::Interface<ICommandLineReader>{
+class ICommandLineReader : private sfun::Interface<ICommandLineReader> {
 public:
     virtual CommandLineReadResult read(const std::vector<std::string>& cmdLine) = 0;
     virtual const std::string& versionInfo() const = 0;
@@ -61,6 +61,6 @@ protected:
     }
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_ICOMMANDLINEREADER_H

--- a/include/cmdlime/detail/iflag.h
+++ b/include/cmdlime/detail/iflag.h
@@ -3,16 +3,16 @@
 
 #include "ioption.h"
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 class OptionInfo;
 
-class IFlag : public IOption{
+class IFlag : public IOption {
 public:
     virtual void set() = 0;
     virtual bool isSet() const = 0;
     virtual bool isExitFlag() const = 0;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_IFLAG_H

--- a/include/cmdlime/detail/initializedoptional.h
+++ b/include/cmdlime/detail/initializedoptional.h
@@ -1,42 +1,47 @@
 #ifndef CMDLIME_INITIALIZEDOPTIONAL_H
 #define CMDLIME_INITIALIZEDOPTIONAL_H
 
-#include <utility>
-#include <stdexcept>
 #include <optional>
+#include <stdexcept>
+#include <utility>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 template<typename T>
-class InitializedOptional
-{
+class InitializedOptional {
 public:
     using value_type = T;
 
-    InitializedOptional()   = default;
+    InitializedOptional() = default;
     InitializedOptional(std::nullopt_t){};
-    template<typename... TArgs, std::enable_if_t<(sizeof...(TArgs)>1)>* = nullptr>
+    template<typename... TArgs, std::enable_if_t<(sizeof...(TArgs) > 1)>* = nullptr>
     InitializedOptional(TArgs&&... args)
         : value_{std::forward<TArgs>(args)...}
     {
     }
 
-    template<typename TArg, std::enable_if_t<!std::is_base_of_v<InitializedOptional<T>, std::remove_reference_t<TArg>> &&
-                                             !std::is_convertible_v<std::remove_reference_t<TArg>, InitializedOptional<T>>>* = nullptr>
+    template<
+            typename TArg,
+            std::enable_if_t<
+                    !std::is_base_of_v<InitializedOptional<T>, std::remove_reference_t<TArg>> &&
+                    !std::is_convertible_v<std::remove_reference_t<TArg>, InitializedOptional<T>>>* = nullptr>
     InitializedOptional(TArg&& arg)
         : value_{std::forward<TArg>(arg)}
     {
     }
 
     template<class... Args>
-    void emplace(Args&& ...args)
+    void emplace(Args&&... args)
     {
         value_ = T{std::forward<Args>(args)...};
         hasValue_ = true;
     }
 
-    template<typename TArg, std::enable_if_t<!std::is_base_of_v<InitializedOptional<T>, std::remove_reference_t<TArg>> &&
-                                             !std::is_same_v<std::nullopt_t, std::remove_cv_t<std::remove_reference_t<TArg>>>>* = nullptr>
+    template<
+            typename TArg,
+            std::enable_if_t<
+                    !std::is_base_of_v<InitializedOptional<T>, std::remove_reference_t<TArg>> &&
+                    !std::is_same_v<std::nullopt_t, std::remove_cv_t<std::remove_reference_t<TArg>>>>* = nullptr>
     InitializedOptional& operator=(TArg&& arg)
     {
         value_ = std::forward<TArg>(arg);
@@ -112,186 +117,185 @@ private:
     bool hasValue_ = false;
 };
 
-template< class T, class U >
+template<class T, class U>
 bool operator==(const InitializedOptional<T>& lhs, const InitializedOptional<U>& rhs)
 {
-     return static_cast<bool>(lhs) == static_cast<bool>(rhs) && (!lhs || *lhs == *rhs);
+    return static_cast<bool>(lhs) == static_cast<bool>(rhs) && (!lhs || *lhs == *rhs);
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator!=(const InitializedOptional<T>& lhs, const InitializedOptional<U>& rhs)
 {
     return static_cast<bool>(lhs) != static_cast<bool>(rhs) || (static_cast<bool>(lhs) && *lhs != *rhs);
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator<(const InitializedOptional<T>& lhs, const InitializedOptional<U>& rhs)
 {
     return static_cast<bool>(rhs) && (!lhs || *lhs < *rhs);
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator<=(const InitializedOptional<T>& lhs, const InitializedOptional<U>& rhs)
 {
     return !lhs || (static_cast<bool>(rhs) && *lhs <= *rhs);
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator>(const InitializedOptional<T>& lhs, const InitializedOptional<U>& rhs)
 {
     return static_cast<bool>(lhs) && (!rhs || *lhs > *rhs);
 }
-template< class T, class U >
+template<class T, class U>
 bool operator>=(const InitializedOptional<T>& lhs, const InitializedOptional<U>& rhs)
 {
     return !rhs || (static_cast<bool>(lhs) && *lhs >= *rhs);
 }
 
-template< class T >
+template<class T>
 bool operator==(const InitializedOptional<T>& lhs, std::nullopt_t)
 {
     return !lhs;
 }
 
-template< class T >
+template<class T>
 bool operator==(std::nullopt_t, const InitializedOptional<T>& rhs)
 {
     return !rhs;
 }
 
-template< class T >
+template<class T>
 bool operator!=(const InitializedOptional<T>& lhs, std::nullopt_t)
 {
     return static_cast<bool>(lhs);
 }
 
-template< class T >
+template<class T>
 bool operator!=(std::nullopt_t, const InitializedOptional<T>& rhs)
 {
     return static_cast<bool>(rhs);
 }
 
-template< class T >
+template<class T>
 bool operator<(const InitializedOptional<T>&, std::nullopt_t)
 {
     return false;
 }
 
-template< class T >
+template<class T>
 bool operator<(std::nullopt_t, const InitializedOptional<T>& rhs)
 {
     return static_cast<bool>(rhs);
 }
 
-template< class T >
+template<class T>
 bool operator<=(const InitializedOptional<T>& lhs, std::nullopt_t)
 {
     return !lhs;
 }
 
-template< class T >
+template<class T>
 bool operator<=(std::nullopt_t, const InitializedOptional<T>&)
 {
     return true;
 }
 
-template< class T >
-bool operator>(const InitializedOptional<T>& lhs, std::nullopt_t )
+template<class T>
+bool operator>(const InitializedOptional<T>& lhs, std::nullopt_t)
 {
     return static_cast<bool>(lhs);
 }
 
-template< class T >
+template<class T>
 bool operator>(std::nullopt_t, const InitializedOptional<T>&)
 {
     return false;
 }
 
-template< class T >
-bool operator>=( const InitializedOptional<T>&, std::nullopt_t)
+template<class T>
+bool operator>=(const InitializedOptional<T>&, std::nullopt_t)
 {
     return true;
 }
 
-template< class T >
+template<class T>
 bool operator>=(std::nullopt_t, const InitializedOptional<T>& rhs)
 {
     return !rhs;
 }
 
-template< class T, class U >
-bool operator==( const InitializedOptional<T>& lhs, const U& rhs)
+template<class T, class U>
+bool operator==(const InitializedOptional<T>& lhs, const U& rhs)
 {
-     return lhs && *lhs == rhs;
+    return lhs && *lhs == rhs;
 }
 
-template< class T, class U >
-bool operator==( const U& lhs, const InitializedOptional<T>& rhs)
+template<class T, class U>
+bool operator==(const U& lhs, const InitializedOptional<T>& rhs)
 {
     return rhs && lhs == *rhs;
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator!=(const InitializedOptional<T>& lhs, const U& rhs)
 {
     return !lhs || *lhs != rhs;
 }
 
-template< class T, class U >
-bool operator!=( const U& lhs, const InitializedOptional<T>& rhs )
+template<class T, class U>
+bool operator!=(const U& lhs, const InitializedOptional<T>& rhs)
 {
     return !rhs || lhs != *rhs;
 }
 
-template< class T, class U >
-bool operator<( const InitializedOptional<T>& lhs, const U& rhs)
+template<class T, class U>
+bool operator<(const InitializedOptional<T>& lhs, const U& rhs)
 {
     return !lhs || *lhs < rhs;
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator<(const U& lhs, const InitializedOptional<T>& rhs)
 {
     return rhs && lhs < *rhs;
 }
 
-template< class T, class U >
-bool operator<=( const InitializedOptional<T>& lhs, const U& rhs )
+template<class T, class U>
+bool operator<=(const InitializedOptional<T>& lhs, const U& rhs)
 {
     return !lhs || *lhs <= rhs;
 }
 
-template< class T, class U >
-bool operator<=( const U& lhs, const InitializedOptional<T>& rhs)
+template<class T, class U>
+bool operator<=(const U& lhs, const InitializedOptional<T>& rhs)
 {
     return rhs && lhs <= *rhs;
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator>(const InitializedOptional<T>& lhs, const U& rhs)
 {
     return lhs && *lhs > rhs;
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator>(const U& lhs, const InitializedOptional<T>& rhs)
 {
     return !rhs || lhs > *rhs;
 }
 
-template< class T, class U >
+template<class T, class U>
 bool operator>=(const InitializedOptional<T>& lhs, const U& rhs)
 {
     return lhs && *lhs >= rhs;
 }
 
-template< class T, class U >
-bool operator>=( const U& lhs, const InitializedOptional<T>& rhs)
+template<class T, class U>
+bool operator>=(const U& lhs, const InitializedOptional<T>& rhs)
 {
     return !rhs || lhs >= *rhs;
 }
 
-
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_INITIALIZEDOPTIONAL_H

--- a/include/cmdlime/detail/ioption.h
+++ b/include/cmdlime/detail/ioption.h
@@ -1,6 +1,7 @@
 #ifndef CMDLIME_IOPTION_H
 #define CMDLIME_IOPTION_H
 
+#include "external/sfun/interface.h"
 #include <string>
 
 namespace cmdlime::detail{
@@ -17,15 +18,8 @@ enum class OptionType{
     ParamList
 };
 
-class IOption{
+class IOption : private sfun::Interface<IOption>{
 public:
-    IOption() = default;
-    virtual ~IOption() = default;
-    IOption(const OptionInfo& info) = delete;
-    IOption& operator=(const OptionInfo& info) = delete;
-    IOption(OptionInfo&& info) = delete;
-    IOption& operator=(OptionInfo&& info) = delete;
-
     virtual OptionInfo& info() = 0;
     virtual const OptionInfo& info() const = 0;
     virtual OptionType type() const = 0;

--- a/include/cmdlime/detail/ioption.h
+++ b/include/cmdlime/detail/ioption.h
@@ -4,10 +4,10 @@
 #include "external/sfun/interface.h"
 #include <string>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 class OptionInfo;
 
-enum class OptionType{
+enum class OptionType {
     Arg,
     ArgList,
     Command,
@@ -18,12 +18,12 @@ enum class OptionType{
     ParamList
 };
 
-class IOption : private sfun::Interface<IOption>{
+class IOption : private sfun::Interface<IOption> {
 public:
     virtual OptionInfo& info() = 0;
     virtual const OptionInfo& info() const = 0;
     virtual OptionType type() const = 0;
 };
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_IOPTION_H

--- a/include/cmdlime/detail/iparam.h
+++ b/include/cmdlime/detail/iparam.h
@@ -4,17 +4,17 @@
 #include "ioption.h"
 #include <string>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 class OptionInfo;
 
-class IParam : public IOption{
+class IParam : public IOption {
 public:
-    virtual bool read(const std::string& data)  = 0;
+    virtual bool read(const std::string& data) = 0;
     virtual bool hasValue() const = 0;
     virtual bool isOptional() const = 0;
     virtual std::string defaultValue() const = 0;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_IPARAM_H

--- a/include/cmdlime/detail/iparamlist.h
+++ b/include/cmdlime/detail/iparamlist.h
@@ -4,17 +4,17 @@
 #include "ioption.h"
 #include <string>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 class OptionInfo;
 
-class IParamList : public IOption{
+class IParamList : public IOption {
 public:
-    virtual bool read(const std::string& data)  = 0;
+    virtual bool read(const std::string& data) = 0;
     virtual bool hasValue() const = 0;
     virtual bool isOptional() const = 0;
     virtual std::string defaultValue() const = 0;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_IPARAMLIST_H

--- a/include/cmdlime/detail/ivalidator.h
+++ b/include/cmdlime/detail/ivalidator.h
@@ -6,12 +6,12 @@
 
 namespace cmdlime::detail {
 
-class IValidator : private sfun::Interface<IValidator>{
+class IValidator : private sfun::Interface<IValidator> {
 public:
     virtual void validate(const std::string& commandName) const = 0;
     virtual OptionType optionType() const = 0;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_IVALIDATOR_H

--- a/include/cmdlime/detail/ivalidator.h
+++ b/include/cmdlime/detail/ivalidator.h
@@ -1,18 +1,13 @@
 #ifndef CMDLIME_IVALIDATOR_H
 #define CMDLIME_IVALIDATOR_H
+
 #include "ioption.h"
+#include "external/sfun/interface.h"
 
 namespace cmdlime::detail {
 
-class IValidator{
+class IValidator : private sfun::Interface<IValidator>{
 public:
-    IValidator() = default;
-    virtual ~IValidator() = default;
-    IValidator(const IValidator&) = delete;
-    IValidator& operator=(const IValidator&) = delete;
-    IValidator(IValidator&&) = delete;
-    IValidator& operator=(IValidator&&) = delete;
-
     virtual void validate(const std::string& commandName) const = 0;
     virtual OptionType optionType() const = 0;
 };

--- a/include/cmdlime/detail/nameformat.h
+++ b/include/cmdlime/detail/nameformat.h
@@ -2,25 +2,25 @@
 #define CMDLIME_NAMEFORMAT_H
 
 #include "gnuformat.h"
-#include "simpleformat.h"
 #include "posixformat.h"
+#include "simpleformat.h"
 #include "x11format.h"
 #include "external/sfun/utility.h"
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-struct NameFormat{
+struct NameFormat {
     static std::string name(Format format, const std::string& varName)
     {
         switch (format) {
-            case Format::Simple:
-                return FormatCfg<Format::Simple>::nameProvider::name(varName);
-            case Format::POSIX:
-                return FormatCfg<Format::POSIX>::nameProvider::name(varName);
-            case Format::X11:
-                return FormatCfg<Format::X11>::nameProvider::name(varName);
-            case Format::GNU:
-                return FormatCfg<Format::GNU>::nameProvider::name(varName);
+        case Format::Simple:
+            return FormatCfg<Format::Simple>::nameProvider::name(varName);
+        case Format::POSIX:
+            return FormatCfg<Format::POSIX>::nameProvider::name(varName);
+        case Format::X11:
+            return FormatCfg<Format::X11>::nameProvider::name(varName);
+        case Format::GNU:
+            return FormatCfg<Format::GNU>::nameProvider::name(varName);
         }
         sfun::unreachable();
     }
@@ -28,47 +28,47 @@ struct NameFormat{
     static std::string shortName(Format format, const std::string& varName)
     {
         switch (format) {
-            case Format::Simple:
-                return FormatCfg<Format::Simple>::nameProvider::shortName(varName);
-            case Format::POSIX:
-                return FormatCfg<Format::POSIX>::nameProvider::shortName(varName);
-            case Format::X11:
-                return FormatCfg<Format::X11>::nameProvider::shortName(varName);
-            case Format::GNU:
-                return FormatCfg<Format::GNU>::nameProvider::shortName(varName);
+        case Format::Simple:
+            return FormatCfg<Format::Simple>::nameProvider::shortName(varName);
+        case Format::POSIX:
+            return FormatCfg<Format::POSIX>::nameProvider::shortName(varName);
+        case Format::X11:
+            return FormatCfg<Format::X11>::nameProvider::shortName(varName);
+        case Format::GNU:
+            return FormatCfg<Format::GNU>::nameProvider::shortName(varName);
         }
         sfun::unreachable();
     }
     static std::string fullName(Format format, const std::string& varName)
     {
         switch (format) {
-            case Format::Simple:
-                return FormatCfg<Format::Simple>::nameProvider::fullName(varName);
-            case Format::POSIX:
-                return FormatCfg<Format::POSIX>::nameProvider::fullName(varName);
-            case Format::X11:
-                return FormatCfg<Format::X11>::nameProvider::fullName(varName);
-            case Format::GNU:
-                return FormatCfg<Format::GNU>::nameProvider::fullName(varName);
+        case Format::Simple:
+            return FormatCfg<Format::Simple>::nameProvider::fullName(varName);
+        case Format::POSIX:
+            return FormatCfg<Format::POSIX>::nameProvider::fullName(varName);
+        case Format::X11:
+            return FormatCfg<Format::X11>::nameProvider::fullName(varName);
+        case Format::GNU:
+            return FormatCfg<Format::GNU>::nameProvider::fullName(varName);
         }
         sfun::unreachable();
     }
     static std::string valueName(Format format, const std::string& type)
     {
         switch (format) {
-            case Format::Simple:
-                return FormatCfg<Format::Simple>::nameProvider::valueName(type);
-            case Format::POSIX:
-                return FormatCfg<Format::POSIX>::nameProvider::valueName(type);
-            case Format::X11:
-                return FormatCfg<Format::X11>::nameProvider::valueName(type);
-            case Format::GNU:
-                return FormatCfg<Format::GNU>::nameProvider::valueName(type);
+        case Format::Simple:
+            return FormatCfg<Format::Simple>::nameProvider::valueName(type);
+        case Format::POSIX:
+            return FormatCfg<Format::POSIX>::nameProvider::valueName(type);
+        case Format::X11:
+            return FormatCfg<Format::X11>::nameProvider::valueName(type);
+        case Format::GNU:
+            return FormatCfg<Format::GNU>::nameProvider::valueName(type);
         }
         sfun::unreachable();
     }
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_NAMEFORMAT_H

--- a/include/cmdlime/detail/nameformat.h
+++ b/include/cmdlime/detail/nameformat.h
@@ -5,7 +5,7 @@
 #include "simpleformat.h"
 #include "posixformat.h"
 #include "x11format.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/utility.h"
 
 namespace cmdlime::detail{
 
@@ -22,7 +22,7 @@ struct NameFormat{
             case Format::GNU:
                 return FormatCfg<Format::GNU>::nameProvider::name(varName);
         }
-        sfun::assert::ensureNotReachable();
+        sfun::unreachable();
     }
 
     static std::string shortName(Format format, const std::string& varName)
@@ -37,7 +37,7 @@ struct NameFormat{
             case Format::GNU:
                 return FormatCfg<Format::GNU>::nameProvider::shortName(varName);
         }
-        sfun::assert::ensureNotReachable();
+        sfun::unreachable();
     }
     static std::string fullName(Format format, const std::string& varName)
     {
@@ -51,7 +51,7 @@ struct NameFormat{
             case Format::GNU:
                 return FormatCfg<Format::GNU>::nameProvider::fullName(varName);
         }
-        sfun::assert::ensureNotReachable();
+        sfun::unreachable();
     }
     static std::string valueName(Format format, const std::string& type)
     {
@@ -65,7 +65,7 @@ struct NameFormat{
             case Format::GNU:
                 return FormatCfg<Format::GNU>::nameProvider::valueName(type);
         }
-        sfun::assert::ensureNotReachable();
+        sfun::unreachable();
     }
 };
 

--- a/include/cmdlime/detail/nameutils.h
+++ b/include/cmdlime/detail/nameutils.h
@@ -2,29 +2,41 @@
 #define CMDLIME_NAMEUTILS_H
 
 #include "external/sfun/string_utils.h"
-#include <string>
 #include <algorithm>
+#include <string>
 #include <type_traits>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-namespace util{
+namespace util {
 
 inline std::string formatName(const std::string& name)
 {
     auto result = name;
     //remove front non-alphabet characters
-    result.erase(result.begin(), std::find_if(result.begin(), result.end(),
-        [](char ch){
-            return sfun::isalpha(ch);
-        })
-    );
+    result.erase(
+            result.begin(),
+            std::find_if(
+                    result.begin(),
+                    result.end(),
+                    [](char ch)
+                    {
+                        return sfun::isalpha(ch);
+                    }));
     //remove back non-alphabet and non-digit characters
-    result.erase(std::find_if(result.rbegin(), result.rend(),
-        [](char ch){ return sfun::isalnum(ch);}).base(), result.end());
+    result.erase(
+            std::find_if(
+                    result.rbegin(),
+                    result.rend(),
+                    [](char ch)
+                    {
+                        return sfun::isalnum(ch);
+                    })
+                    .base(),
+            result.end());
     return result;
 }
-}
+} //namespace util
 
 inline std::string toCamelCase(const std::string& name)
 {
@@ -33,8 +45,8 @@ inline std::string toCamelCase(const std::string& name)
     auto formattedName = util::formatName(name);
     if (!formattedName.empty())
         formattedName[0] = sfun::tolower(formattedName[0]);
-    for (auto ch : formattedName){
-        if (!std::isalpha(ch)){
+    for (auto ch : formattedName) {
+        if (!std::isalpha(ch)) {
             if (std::isdigit(ch))
                 result.push_back(ch);
             if (!result.empty())
@@ -55,8 +67,8 @@ inline std::string toKebabCase(const std::string& name)
     auto formattedName = util::formatName(sfun::replace(name, "_", "-"));
     if (!formattedName.empty())
         formattedName[0] = sfun::tolower(formattedName[0]);
-    for (auto ch : formattedName){
-        if (std::isupper(ch) && !result.empty()){
+    for (auto ch : formattedName) {
+        if (std::isupper(ch) && !result.empty()) {
             result.push_back('-');
             result.push_back(sfun::tolower(ch));
         }
@@ -69,7 +81,7 @@ inline std::string toKebabCase(const std::string& name)
 inline std::string toLowerCase(const std::string& name)
 {
     auto result = std::string{};
-    for (auto ch : util::formatName(name)){
+    for (auto ch : util::formatName(name)) {
         if (sfun::isalnum(ch))
             result.push_back(sfun::tolower(ch));
     }
@@ -91,6 +103,6 @@ inline std::string templateType(const std::string& type)
     return type;
 }
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_NAMEUTILS_H

--- a/include/cmdlime/detail/nameutils.h
+++ b/include/cmdlime/detail/nameutils.h
@@ -7,7 +7,6 @@
 #include <type_traits>
 
 namespace cmdlime::detail{
-namespace str = sfun::string_utils;
 
 namespace util{
 
@@ -17,12 +16,12 @@ inline std::string formatName(const std::string& name)
     //remove front non-alphabet characters
     result.erase(result.begin(), std::find_if(result.begin(), result.end(),
         [](char ch){
-            return str::isalpha(ch);
+            return sfun::isalpha(ch);
         })
     );
     //remove back non-alphabet and non-digit characters
     result.erase(std::find_if(result.rbegin(), result.rend(),
-        [](char ch){ return str::isalnum(ch);}).base(), result.end());
+        [](char ch){ return sfun::isalnum(ch);}).base(), result.end());
     return result;
 }
 }
@@ -33,7 +32,7 @@ inline std::string toCamelCase(const std::string& name)
     auto prevCharNonAlpha = false;
     auto formattedName = util::formatName(name);
     if (!formattedName.empty())
-        formattedName[0] = str::tolower(formattedName[0]);
+        formattedName[0] = sfun::tolower(formattedName[0]);
     for (auto ch : formattedName){
         if (!std::isalpha(ch)){
             if (std::isdigit(ch))
@@ -43,7 +42,7 @@ inline std::string toCamelCase(const std::string& name)
             continue;
         }
         if (prevCharNonAlpha)
-            ch = str::toupper(ch);
+            ch = sfun::toupper(ch);
         result.push_back(ch);
         prevCharNonAlpha = false;
     }
@@ -53,13 +52,13 @@ inline std::string toCamelCase(const std::string& name)
 inline std::string toKebabCase(const std::string& name)
 {
     auto result = std::string{};
-    auto formattedName = util::formatName(str::replace(name, "_", "-"));
+    auto formattedName = util::formatName(sfun::replace(name, "_", "-"));
     if (!formattedName.empty())
-        formattedName[0] = str::tolower(formattedName[0]);
+        formattedName[0] = sfun::tolower(formattedName[0]);
     for (auto ch : formattedName){
         if (std::isupper(ch) && !result.empty()){
             result.push_back('-');
-            result.push_back(str::tolower(ch));
+            result.push_back(sfun::tolower(ch));
         }
         else
             result.push_back(ch);
@@ -71,8 +70,8 @@ inline std::string toLowerCase(const std::string& name)
 {
     auto result = std::string{};
     for (auto ch : util::formatName(name)){
-        if (str::isalnum(ch))
-            result.push_back(str::tolower(ch));
+        if (sfun::isalnum(ch))
+            result.push_back(sfun::tolower(ch));
     }
     return result;
 }
@@ -88,7 +87,7 @@ inline std::string typeNameWithoutNamespace(const std::string& type)
 inline std::string templateType(const std::string& type)
 {
     if (type.find('<') != std::string::npos)
-        return std::string{str::before(str::after(type, "<"), ">")};
+        return std::string{sfun::before(sfun::after(type, "<"), ">")};
     return type;
 }
 

--- a/include/cmdlime/detail/optioninfo.h
+++ b/include/cmdlime/detail/optioninfo.h
@@ -2,13 +2,13 @@
 #define CMDLIME_OPTIONINFO_H
 
 #include "external/sfun/contract.h"
-#include <string>
 #include <sstream>
+#include <string>
 #include <utility>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-class OptionInfo{
+class OptionInfo {
 public:
     OptionInfo(std::string name, std::string shortName, std::string valueName)
         : name_(std::move(name))
@@ -66,6 +66,6 @@ private:
     std::string description_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_OPTIONINFO_H

--- a/include/cmdlime/detail/optioninfo.h
+++ b/include/cmdlime/detail/optioninfo.h
@@ -1,7 +1,7 @@
 #ifndef CMDLIME_OPTIONINFO_H
 #define CMDLIME_OPTIONINFO_H
 
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 #include <string>
 #include <sstream>
 #include <utility>

--- a/include/cmdlime/detail/options.h
+++ b/include/cmdlime/detail/options.h
@@ -1,16 +1,16 @@
 #ifndef CMDLIME_OPTIONS_H
 #define CMDLIME_OPTIONS_H
 
-#include "iparam.h"
-#include "iparamlist.h"
-#include "iflag.h"
 #include "iarg.h"
 #include "iarglist.h"
 #include "icommand.h"
-#include <vector>
+#include "iflag.h"
+#include "iparam.h"
+#include "iparamlist.h"
 #include <memory>
+#include <vector>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 class Options {
 public:
@@ -83,6 +83,6 @@ private:
     std::vector<std::unique_ptr<ICommand>> commands_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_OPTIONS_H

--- a/include/cmdlime/detail/param.h
+++ b/include/cmdlime/detail/param.h
@@ -6,14 +6,13 @@
 #include <cmdlime/errors.h>
 #include <cmdlime/customnames.h>
 #include <cmdlime/stringconverter.h>
-#include "external/sfun/traits.h"
+#include "external/sfun/type_traits.h"
 #include <sstream>
 #include <optional>
 #include <memory>
 #include <functional>
 
 namespace cmdlime::detail{
-using namespace sfun::traits;
 
 template<typename T>
 class Param : public IParam{
@@ -62,7 +61,7 @@ private:
 
     bool hasValue() const override
     {
-        if constexpr (is_optional_v<T>)
+        if constexpr (sfun::is_optional_v<T>)
             return true;
         else
             return hasValue_;
@@ -70,7 +69,7 @@ private:
 
     bool isOptional() const override
     {
-        if constexpr (is_optional_v<T>)
+        if constexpr (sfun::is_optional_v<T>)
             return true;
         else
             return defaultValue_.has_value();

--- a/include/cmdlime/detail/param.h
+++ b/include/cmdlime/detail/param.h
@@ -3,24 +3,21 @@
 
 #include "iparam.h"
 #include "optioninfo.h"
-#include <cmdlime/errors.h>
-#include <cmdlime/customnames.h>
-#include <cmdlime/stringconverter.h>
 #include "external/sfun/type_traits.h"
-#include <sstream>
-#include <optional>
-#include <memory>
+#include <cmdlime/customnames.h>
+#include <cmdlime/errors.h>
+#include <cmdlime/stringconverter.h>
 #include <functional>
+#include <memory>
+#include <optional>
+#include <sstream>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 template<typename T>
-class Param : public IParam{
+class Param : public IParam {
 public:
-    Param(std::string name,
-          std::string shortName,
-          std::string type,
-          T& paramValue)
+    Param(std::string name, std::string shortName, std::string type, T& paramValue)
         : info_(std::move(name), std::move(shortName), std::move(type))
         , paramValue_(paramValue)
     {
@@ -94,6 +91,6 @@ private:
     bool hasValue_ = false;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_PARAM_H

--- a/include/cmdlime/detail/paramcreator.h
+++ b/include/cmdlime/detail/paramcreator.h
@@ -1,21 +1,18 @@
 #ifndef CMDLIME_PARAMCREATOR_H
 #define CMDLIME_PARAMCREATOR_H
 
-#include "param.h"
 #include "icommandlinereader.h"
 #include "nameformat.h"
+#include "param.h"
 #include "validator.h"
 #include "external/sfun/contract.h"
 
 namespace cmdlime::detail {
 
 template<typename T>
-class ParamCreator{
+class ParamCreator {
 public:
-    ParamCreator(CommandLineReaderPtr reader,
-                 const std::string& varName,
-                 const std::string& type,
-                 T& paramValue)
+    ParamCreator(CommandLineReaderPtr reader, const std::string& varName, const std::string& type, T& paramValue)
         : reader_(reader)
         , paramValue_(paramValue)
     {
@@ -88,6 +85,6 @@ private:
     T& paramValue_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_PARAMCREATOR_H

--- a/include/cmdlime/detail/paramcreator.h
+++ b/include/cmdlime/detail/paramcreator.h
@@ -5,7 +5,7 @@
 #include "icommandlinereader.h"
 #include "nameformat.h"
 #include "validator.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 
 namespace cmdlime::detail {
 

--- a/include/cmdlime/detail/paramlist.h
+++ b/include/cmdlime/detail/paramlist.h
@@ -3,27 +3,24 @@
 
 #include "iparamlist.h"
 #include "optioninfo.h"
-#include <cmdlime/errors.h>
-#include <cmdlime/customnames.h>
-#include <cmdlime/stringconverter.h>
 #include "external/sfun/string_utils.h"
 #include "external/sfun/type_traits.h"
-#include <vector>
-#include <sstream>
+#include <cmdlime/customnames.h>
+#include <cmdlime/errors.h>
+#include <cmdlime/stringconverter.h>
 #include <functional>
 #include <memory>
+#include <sstream>
+#include <vector>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <typename TParamList>
-class ParamList : public IParamList{
+template<typename TParamList>
+class ParamList : public IParamList {
     static_assert(sfun::is_dynamic_sequence_container_v<TParamList>, "Param list field must be a sequence container");
 
 public:
-    ParamList(std::string name,
-              std::string shortName,
-              std::string type,
-              TParamList& paramListValue)
+    ParamList(std::string name, std::string shortName, std::string type, TParamList& paramListValue)
         : info_(std::move(name), std::move(shortName), std::move(type))
         , paramListValue_(paramListValue)
     {
@@ -53,13 +50,13 @@ public:
 private:
     bool read(const std::string& data) override
     {
-        if (!isDefaultValueOverwritten_){
+        if (!isDefaultValueOverwritten_) {
             paramListValue_.clear();
             isDefaultValueOverwritten_ = true;
         }
 
         const auto dataParts = sfun::split(data, ",");
-        for (const auto& part : dataParts){
+        for (const auto& part : dataParts) {
             auto paramVal = convertFromString<typename TParamList::value_type>(std::string{part});
             if (!paramVal)
                 return false;
@@ -86,7 +83,7 @@ private:
         auto stream = std::stringstream{};
         stream << "{";
         auto firstVal = true;
-        for (auto& val : *defaultValue_){
+        for (auto& val : *defaultValue_) {
             auto valStr = convertToString(val);
             if (!valStr)
                 return {};
@@ -112,6 +109,6 @@ private:
     bool isDefaultValueOverwritten_ = false;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_PARAMLIST_H

--- a/include/cmdlime/detail/paramlist.h
+++ b/include/cmdlime/detail/paramlist.h
@@ -7,17 +7,17 @@
 #include <cmdlime/customnames.h>
 #include <cmdlime/stringconverter.h>
 #include "external/sfun/string_utils.h"
+#include "external/sfun/type_traits.h"
 #include <vector>
 #include <sstream>
 #include <functional>
 #include <memory>
 
 namespace cmdlime::detail{
-namespace str = sfun::string_utils;
 
 template <typename TParamList>
 class ParamList : public IParamList{
-    static_assert(is_dynamic_sequence_container_v<TParamList>, "Param list field must be a sequence container");
+    static_assert(sfun::is_dynamic_sequence_container_v<TParamList>, "Param list field must be a sequence container");
 
 public:
     ParamList(std::string name,
@@ -58,7 +58,7 @@ private:
             isDefaultValueOverwritten_ = true;
         }
 
-        const auto dataParts = str::split(data, ",");
+        const auto dataParts = sfun::split(data, ",");
         for (const auto& part : dataParts){
             auto paramVal = convertFromString<typename TParamList::value_type>(std::string{part});
             if (!paramVal)

--- a/include/cmdlime/detail/paramlistcreator.h
+++ b/include/cmdlime/detail/paramlistcreator.h
@@ -5,15 +5,14 @@
 #include "icommandlinereader.h"
 #include "nameformat.h"
 #include "validator.h"
-#include "external/sfun/traits.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/type_traits.h"
+#include "external/sfun/contract.h"
 
 namespace cmdlime::detail {
-using namespace sfun::traits;
 
 template<typename TParamList>
 class ParamListCreator{
-    static_assert(is_dynamic_sequence_container_v<TParamList>, "Param list field must be a sequence container");
+    static_assert(sfun::is_dynamic_sequence_container_v<TParamList>, "Param list field must be a sequence container");
 
 public:
     ParamListCreator(CommandLineReaderPtr reader,

--- a/include/cmdlime/detail/paramlistcreator.h
+++ b/include/cmdlime/detail/paramlistcreator.h
@@ -1,26 +1,27 @@
 #ifndef CMDLIME_PARAMLISTCREATOR_H
 #define CMDLIME_PARAMLISTCREATOR_H
 
-#include "paramlist.h"
 #include "icommandlinereader.h"
 #include "nameformat.h"
+#include "paramlist.h"
 #include "validator.h"
-#include "external/sfun/type_traits.h"
 #include "external/sfun/contract.h"
+#include "external/sfun/type_traits.h"
 
 namespace cmdlime::detail {
 
 template<typename TParamList>
-class ParamListCreator{
+class ParamListCreator {
     static_assert(sfun::is_dynamic_sequence_container_v<TParamList>, "Param list field must be a sequence container");
 
 public:
-    ParamListCreator(CommandLineReaderPtr reader,
-                     const std::string& varName,
-                     const std::string& type,
-                     TParamList& paramListValue)
-            : reader_(reader)
-            , paramListValue_(paramListValue)
+    ParamListCreator(
+            CommandLineReaderPtr reader,
+            const std::string& varName,
+            const std::string& type,
+            TParamList& paramListValue)
+        : reader_(reader)
+        , paramListValue_(paramListValue)
     {
         sfunPrecondition(!varName.empty());
         sfunPrecondition(!type.empty());
@@ -71,7 +72,6 @@ public:
         return *this;
     }
 
-
     auto& operator()(TParamList defaultValue = {})
     {
         defaultValue_ = std::move(defaultValue);
@@ -93,6 +93,6 @@ private:
     TParamList& paramListValue_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_PARAMLISTCREATOR_H

--- a/include/cmdlime/detail/parser.h
+++ b/include/cmdlime/detail/parser.h
@@ -1,29 +1,29 @@
 #ifndef CMDLIME_PARSER_H
 #define CMDLIME_PARSER_H
 
-#include "iparam.h"
-#include "iparamlist.h"
-#include "iflag.h"
+#include "formatcfg.h"
 #include "iarg.h"
 #include "iarglist.h"
 #include "icommand.h"
+#include "iflag.h"
+#include "iparam.h"
+#include "iparamlist.h"
 #include "options.h"
-#include "formatcfg.h"
 #include <cmdlime/errors.h>
-#include <utility>
-#include <vector>
-#include <deque>
-#include <unordered_set>
 #include <algorithm>
+#include <deque>
 #include <functional>
 #include <optional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <Format formatType>
-class Parser{
+template<Format formatType>
+class Parser {
 protected:
-    enum class ReadMode{
+    enum class ReadMode {
         All,
         Args,
         Commands,
@@ -33,7 +33,7 @@ protected:
 private:
     using OutputFormatter = typename FormatCfg<formatType>::outputFormatter;
 
-    class ReadModeScope{
+    class ReadModeScope {
     public:
         ReadModeScope(ReadMode value, ReadMode& readMode)
             : readMode_(readMode)
@@ -45,6 +45,7 @@ private:
         {
             readMode_ = originalValue_;
         }
+
     private:
         ReadMode& readMode_;
         ReadMode originalValue_;
@@ -53,7 +54,8 @@ private:
 public:
     explicit Parser(const Options& options)
         : options_(options)
-    {}
+    {
+    }
     virtual ~Parser() = default;
 
     CommandLineReadResult parse(const std::vector<std::string>& cmdLine)
@@ -61,9 +63,14 @@ public:
         checkNames();
         argsToRead_.clear();
 
-        std::transform(options_.args().begin(), options_.args().end(),
-                       std::back_inserter(argsToRead_),
-                       [](auto& arg) ->IArg& { return *arg; });
+        std::transform(
+                options_.args().begin(),
+                options_.args().end(),
+                std::back_inserter(argsToRead_),
+                [](auto& arg) -> IArg&
+                {
+                    return *arg;
+                });
 
         auto readResult = readCommandsAndExitFlags(cmdLine);
         if (readResult)
@@ -71,20 +78,20 @@ public:
 
         preProcess();
         auto argsDelimiterEncountered = false;
-        for (auto i = 0u; i < cmdLine.size(); ++i){
+        for (auto i = 0u; i < cmdLine.size(); ++i) {
             const auto& token = cmdLine.at(i);
-            if (token == "--"){
+            if (token == "--") {
                 argsDelimiterEncountered = true;
                 continue;
             }
-            if (!argsDelimiterEncountered){
+            if (!argsDelimiterEncountered) {
                 process(token);
-                if (foundCommand_){
+                if (foundCommand_) {
                     readCommand(foundCommand_, {cmdLine.begin() + i + 1, cmdLine.end()});
                     break;
                 }
             }
-            else{
+            else {
                 auto modeGuard = setScopeReadMode(ReadMode::Args);
                 readArg(token);
             }
@@ -98,26 +105,29 @@ public:
     }
 
 protected:
-    enum class FindMode{
+    enum class FindMode {
         Name,
         ShortName,
         All
     };
     IParam* findParam(std::string_view name, FindMode mode = FindMode::All)
     {
-        auto paramIt = std::find_if(options_.params().begin(), options_.params().end(),
-            [&](auto& param){
-                switch(mode){
-                case FindMode::Name:
-                    return param->info().name() == name;
-                case FindMode::ShortName:
-                    return param->info().shortName() == name;
-                case FindMode::All:
-                    return param->info().name() == name || param->info().shortName() == name;
-                default:
-                    return false;
-                }
-            });
+        auto paramIt = std::find_if(
+                options_.params().begin(),
+                options_.params().end(),
+                [&](auto& param)
+                {
+                    switch (mode) {
+                    case FindMode::Name:
+                        return param->info().name() == name;
+                    case FindMode::ShortName:
+                        return param->info().shortName() == name;
+                    case FindMode::All:
+                        return param->info().name() == name || param->info().shortName() == name;
+                    default:
+                        return false;
+                    }
+                });
         if (paramIt == options_.params().end())
             return nullptr;
         return paramIt->get();
@@ -125,19 +135,22 @@ protected:
 
     IParamList* findParamList(std::string_view name, FindMode mode = FindMode::All)
     {
-        auto paramListIt = std::find_if(options_.paramLists().begin(), options_.paramLists().end(),
-            [&](auto& paramList){
-                switch(mode){
-                case FindMode::Name:
-                    return paramList->info().name() == name;
-                case FindMode::ShortName:
-                    return paramList->info().shortName() == name;
-                case FindMode::All:
-                    return paramList->info().name() == name || paramList->info().shortName() == name;
-                default:
-                    return false;
-                }
-            });
+        auto paramListIt = std::find_if(
+                options_.paramLists().begin(),
+                options_.paramLists().end(),
+                [&](auto& paramList)
+                {
+                    switch (mode) {
+                    case FindMode::Name:
+                        return paramList->info().name() == name;
+                    case FindMode::ShortName:
+                        return paramList->info().shortName() == name;
+                    case FindMode::All:
+                        return paramList->info().name() == name || paramList->info().shortName() == name;
+                    default:
+                        return false;
+                    }
+                });
         if (paramListIt == options_.paramLists().end())
             return nullptr;
         return paramListIt->get();
@@ -149,37 +162,46 @@ protected:
             return;
 
         if (value.empty())
-            throw ParsingError{"Parameter '" + OutputFormatter::paramPrefix() + std::string{name} + "' value can't be empty"};
+            throw ParsingError{
+                    "Parameter '" + OutputFormatter::paramPrefix() + std::string{name} + "' value can't be empty"};
         auto param = findParam(name);
-        if (param){
+        if (param) {
             if (!param->read(value))
-                throw ParsingError{"Couldn't set parameter '" + OutputFormatter::paramPrefix() + param->info().name() + "' value from '" + value + "'"};
+                throw ParsingError{
+                        "Couldn't set parameter '" + OutputFormatter::paramPrefix() + param->info().name() +
+                        "' value from '" + value + "'"};
             return;
         }
         auto paramList = findParamList(name);
-        if (paramList){
+        if (paramList) {
             if (!paramList->read(value))
-                throw ParsingError{"Couldn't set parameter '" + OutputFormatter::paramPrefix() + paramList->info().name() + "' value from '" + value + "'"};
+                throw ParsingError{
+                        "Couldn't set parameter '" + OutputFormatter::paramPrefix() + paramList->info().name() +
+                        "' value from '" + value + "'"};
             return;
         }
-        throw ParsingError{"Encountered unknown parameter '" + OutputFormatter::paramPrefix() + std::string{name} + "'"};
+        throw ParsingError{
+                "Encountered unknown parameter '" + OutputFormatter::paramPrefix() + std::string{name} + "'"};
     }
 
     IFlag* findFlag(std::string_view name, FindMode mode = FindMode::All)
     {
-        auto flagIt = std::find_if(options_.flags().begin(), options_.flags().end(),
-            [&](auto& flag){
-            switch(mode){
-                case FindMode::Name:
-                    return flag->info().name() == name;
-                case FindMode::ShortName:
-                    return flag->info().shortName() == name;
-                case FindMode::All:
-                    return flag->info().name() == name || flag->info().shortName() == name;
-                default:
-                    return false;
-                }
-            });
+        auto flagIt = std::find_if(
+                options_.flags().begin(),
+                options_.flags().end(),
+                [&](auto& flag)
+                {
+                    switch (mode) {
+                    case FindMode::Name:
+                        return flag->info().name() == name;
+                    case FindMode::ShortName:
+                        return flag->info().shortName() == name;
+                    case FindMode::All:
+                        return flag->info().name() == name || flag->info().shortName() == name;
+                    default:
+                        return false;
+                    }
+                });
         if (flagIt == options_.flags().end())
             return nullptr;
         return flagIt->get();
@@ -187,8 +209,7 @@ protected:
 
     void readFlag(std::string_view name)
     {
-        if (readMode_ != ReadMode::ExitFlagsAndCommands &&
-            readMode_ != ReadMode::All)
+        if (readMode_ != ReadMode::ExitFlagsAndCommands && readMode_ != ReadMode::All)
             return;
 
         auto flag = findFlag(name);
@@ -199,18 +220,16 @@ protected:
 
     void readArg(const std::string& value)
     {
-        if (readMode_ == ReadMode::All ||
-            readMode_ == ReadMode::ExitFlagsAndCommands ||
-            readMode_ == ReadMode::Commands){
+        if (readMode_ == ReadMode::All || readMode_ == ReadMode::ExitFlagsAndCommands ||
+            readMode_ == ReadMode::Commands) {
             foundCommand_ = findCommand(value);
             if (foundCommand_)
                 return;
         }
-        if (readMode_ != ReadMode::Args &&
-            readMode_ != ReadMode::All)
+        if (readMode_ != ReadMode::Args && readMode_ != ReadMode::All)
             return;
 
-        if (!argsToRead_.empty()){
+        if (!argsToRead_.empty()) {
             auto& arg = static_cast<IArg&>(argsToRead_.front());
             if (value.empty())
                 throw ParsingError{"Argument '" + arg.info().name() + "' value can't be empty"};
@@ -218,16 +237,18 @@ protected:
             if (!arg.read(value))
                 throw ParsingError{"Couldn't set argument '" + arg.info().name() + "' value from '" + value + "'"};
         }
-        else if (options_.argList()){
+        else if (options_.argList()) {
             if (value.empty())
-                throw ParsingError{"Argument list '" + options_.argList()->info().name() + "' element value can't be empty"};
+                throw ParsingError{
+                        "Argument list '" + options_.argList()->info().name() + "' element value can't be empty"};
             if (!options_.argList()->read(value))
-                throw ParsingError{"Couldn't set argument list '" + options_.argList()->info().name() + "' element's value from '" + value + "'"};
+                throw ParsingError{
+                        "Couldn't set argument list '" + options_.argList()->info().name() +
+                        "' element's value from '" + value + "'"};
         }
         else
             throw ParsingError("Encountered unknown positional argument '" + value + "'");
     }
-
 
     void forEachParamInfo(const std::function<void(const OptionInfo&)>& handler)
     {
@@ -248,17 +269,19 @@ protected:
     }
 
 private:
-    virtual void preProcess(){}
+    virtual void preProcess() {}
     virtual void process(const std::string& cmdLineToken) = 0;
-    virtual void postProcess(){}
+    virtual void postProcess() {}
 
     ICommand* findCommand(const std::string& name)
     {
-        auto commandIt = std::find_if(options_.commands().begin(), options_.commands().end(),
-            [&](auto& command){
-                return command->info().name() == name;
-
-            });
+        auto commandIt = std::find_if(
+                options_.commands().begin(),
+                options_.commands().end(),
+                [&](auto& command)
+                {
+                    return command->info().name() == name;
+                });
         if (commandIt == options_.commands().end())
             return nullptr;
         return commandIt->get();
@@ -266,13 +289,13 @@ private:
 
     CommandLineReadResult readCommand(ICommand* command, const std::vector<std::string>& cmdLine)
     {
-        try{
+        try {
             return command->read(cmdLine);
         }
-        catch(const ConfigError& error){
+        catch (const ConfigError& error) {
             throw CommandConfigError(command->info().name(), command->usageInfo(), error);
         }
-        catch(const ParsingError& error){
+        catch (const ParsingError& error) {
             throw CommandParsingError(command->info().name(), command->usageInfo(), error);
         }
     }
@@ -282,18 +305,18 @@ private:
         auto modeGuard = setScopeReadMode(ReadMode::ExitFlagsAndCommands);
 
         preProcess();
-        for (auto i = 0u; i < cmdLine.size(); ++i){
+        for (auto i = 0u; i < cmdLine.size(); ++i) {
             const auto& token = cmdLine.at(i);
             if (token == "--")
                 return {};
 
             process(token);
-            if (foundCommand_){
-                if (foundCommand_->isSubCommand()){
+            if (foundCommand_) {
+                if (foundCommand_->isSubCommand()) {
                     foundCommand_ = nullptr;
                     return {};
                 }
-                else{
+                else {
                     auto res = readCommand(foundCommand_, {cmdLine.begin() + i + 1, cmdLine.end()});
                     foundCommand_ = nullptr;
                     return res;
@@ -323,16 +346,18 @@ private:
     {
         for (const auto& param : options_.params())
             if (!param->hasValue())
-                throw ParsingError{"Parameter '" + OutputFormatter::paramPrefix() + param->info().name() + "' is missing."};
+                throw ParsingError{
+                        "Parameter '" + OutputFormatter::paramPrefix() + param->info().name() + "' is missing."};
 
         for (const auto& paramList : options_.paramLists())
             if (!paramList->hasValue())
-                throw ParsingError{"Parameter '" + OutputFormatter::paramPrefix() + paramList->info().name() + "' is missing."};
+                throw ParsingError{
+                        "Parameter '" + OutputFormatter::paramPrefix() + paramList->info().name() + "' is missing."};
     }
 
     void checkUnreadArgs()
     {
-        if(!argsToRead_.empty())
+        if (!argsToRead_.empty())
             throw ParsingError{"Positional argument '" + argsToRead_.front().get().info().name() + "' is missing."};
     }
 
@@ -346,7 +371,8 @@ private:
     {
         auto encounteredNames = std::unordered_set<std::string>{};
 
-        auto processName = [&encounteredNames](const std::string& varType, const OptionInfo& var){
+        auto processName = [&encounteredNames](const std::string& varType, const OptionInfo& var)
+        {
             if (encounteredNames.count(var.name()))
                 throw ConfigError{varType + " name '" + var.name() + "' is already used."};
             encounteredNames.insert(var.name());
@@ -373,6 +399,6 @@ private:
     ICommand* foundCommand_ = nullptr;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_PARSER_H

--- a/include/cmdlime/detail/posixformat.h
+++ b/include/cmdlime/detail/posixformat.h
@@ -1,31 +1,30 @@
 #ifndef CMDLIME_POSIXFORMAT_H
 #define CMDLIME_POSIXFORMAT_H
 
-#include "parser.h"
-#include "nameutils.h"
-#include "utils.h"
 #include "formatcfg.h"
-#include <cmdlime/errors.h>
-#include "external/sfun/string_utils.h"
+#include "nameutils.h"
+#include "parser.h"
+#include "utils.h"
 #include "external/sfun/contract.h"
+#include "external/sfun/string_utils.h"
+#include <cmdlime/errors.h>
 #include <algorithm>
-#include <sstream>
-#include <iomanip>
 #include <functional>
+#include <iomanip>
+#include <sstream>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <Format formatType>
-class PosixParser : public Parser<formatType>
-{
+template<Format formatType>
+class PosixParser : public Parser<formatType> {
     using Parser<formatType>::Parser;
 
     void processCommand(std::string command)
     {
         auto possibleNumberArg = command;
         command = sfun::after(command, "-");
-        if (isParamOrFlag(command)){
-            if (this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands){
+        if (isParamOrFlag(command)) {
+            if (this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands) {
                 if (!foundParam_.empty())
                     throw ParsingError{"Parameter '-" + foundParam_ + "' value can't be empty"};
                 if (argumentEncountered_)
@@ -33,7 +32,7 @@ class PosixParser : public Parser<formatType>
             }
             parseCommand(command);
         }
-        else if (isNumber(possibleNumberArg)){
+        else if (isNumber(possibleNumberArg)) {
             this->readArg(possibleNumberArg);
             argumentEncountered_ = true;
         }
@@ -50,13 +49,13 @@ class PosixParser : public Parser<formatType>
 
     void process(const std::string& token) override
     {
-        if (!foundParam_.empty()){
+        if (!foundParam_.empty()) {
             this->readParam(foundParam_, token);
             foundParam_.clear();
         }
         else if (sfun::startsWith(token, "-") && token.size() > 1)
-           processCommand(token);
-        else{
+            processCommand(token);
+        else {
             this->readArg(token);
             argumentEncountered_ = true;
         }
@@ -73,7 +72,7 @@ class PosixParser : public Parser<formatType>
         if (command.empty())
             throw ParsingError{"Flags and parameters must have a name"};
         auto paramValue = std::string{};
-        for(auto ch : command){
+        for (auto ch : command) {
             auto opt = std::string{ch};
             if (!foundParam_.empty())
                 paramValue += opt;
@@ -84,7 +83,7 @@ class PosixParser : public Parser<formatType>
             else if (this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands)
                 throw ParsingError{"Unknown option '" + opt + "' in command '-" + command + "'"};
         }
-        if (!foundParam_.empty() && !paramValue.empty()){
+        if (!foundParam_.empty() && !paramValue.empty()) {
             this->readParam(foundParam_, paramValue);
             foundParam_.clear();
         }
@@ -92,31 +91,36 @@ class PosixParser : public Parser<formatType>
 
     void checkNames()
     {
-        auto check = [](const OptionInfo& var, const std::string& varType){
+        auto check = [](const OptionInfo& var, const std::string& varType)
+        {
             if (var.name().size() != 1)
                 throw ConfigError{varType + "'s name '" + var.name() + "' can't have more than one symbol"};
             if (!std::isalnum(var.name().front()))
                 throw ConfigError{varType + "'s name '" + var.name() + "' must be an alphanumeric character"};
         };
-        this->forEachParamInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachParamListInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachFlagInfo([check](const OptionInfo& var){
-            check(var, "Flag");
-        });
+        this->forEachParamInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachParamListInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachFlagInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Flag");
+                });
     }
 
     bool isParamOrFlag(const std::string& str)
     {
         if (str.empty())
             return false;
-        auto opt = str.substr(0,1);
-        return this->findFlag(opt) ||
-               this->findParam(opt) ||
-               this->findParamList(opt);
+        auto opt = str.substr(0, 1);
+        return this->findFlag(opt) || this->findParam(opt) || this->findParamList(opt);
     }
 
 private:
@@ -124,7 +128,7 @@ private:
     std::string foundParam_;
 };
 
-class PosixNameProvider{
+class PosixNameProvider {
 public:
     static std::string name(const std::string& optionName)
     {
@@ -151,8 +155,7 @@ public:
     }
 };
 
-
-class PosixOutputFormatter{
+class PosixOutputFormatter {
 public:
     static std::string paramUsageName(const IParam& param)
     {
@@ -177,16 +180,14 @@ public:
     static std::string paramDescriptionName(const IParam& param, int indent = 0)
     {
         auto stream = std::stringstream{};
-        stream << std::setw(indent) << paramPrefix()
-               << param.info().name() << " <" << param.info().valueName() << ">";
+        stream << std::setw(indent) << paramPrefix() << param.info().name() << " <" << param.info().valueName() << ">";
         return stream.str();
     }
 
     static std::string paramListDescriptionName(const IParamList& param, int indent = 0)
     {
         auto stream = std::stringstream{};
-        stream << std::setw(indent) << paramPrefix()
-               << param.info().name() << " <" << param.info().valueName() << ">";
+        stream << std::setw(indent) << paramPrefix() << param.info().name() << " <" << param.info().valueName() << ">";
         return stream.str();
     }
 
@@ -248,18 +249,16 @@ public:
         stream << "<" << argList.info().name() << "> (" << argList.info().valueName() << ")";
         return stream.str();
     }
-
 };
 
 template<>
-struct FormatCfg<Format::POSIX>
-{
+struct FormatCfg<Format::POSIX> {
     using parser = PosixParser<Format::POSIX>;
     using nameProvider = PosixNameProvider;
     using outputFormatter = PosixOutputFormatter;
     static constexpr bool shortNamesEnabled = false;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_POSIXFORMAT_H

--- a/include/cmdlime/detail/posixformat.h
+++ b/include/cmdlime/detail/posixformat.h
@@ -7,14 +7,13 @@
 #include "formatcfg.h"
 #include <cmdlime/errors.h>
 #include "external/sfun/string_utils.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
 #include <functional>
 
 namespace cmdlime::detail{
-namespace str = sfun::string_utils;
 
 template <Format formatType>
 class PosixParser : public Parser<formatType>
@@ -24,7 +23,7 @@ class PosixParser : public Parser<formatType>
     void processCommand(std::string command)
     {
         auto possibleNumberArg = command;
-        command = str::after(command, "-");
+        command = sfun::after(command, "-");
         if (isParamOrFlag(command)){
             if (this->readMode_ != Parser<formatType>::ReadMode::ExitFlagsAndCommands){
                 if (!foundParam_.empty())
@@ -55,7 +54,7 @@ class PosixParser : public Parser<formatType>
             this->readParam(foundParam_, token);
             foundParam_.clear();
         }
-        else if (str::startsWith(token, "-") && token.size() > 1)
+        else if (sfun::startsWith(token, "-") && token.size() > 1)
            processCommand(token);
         else{
             this->readArg(token);

--- a/include/cmdlime/detail/simpleformat.h
+++ b/include/cmdlime/detail/simpleformat.h
@@ -7,14 +7,13 @@
 #include "utils.h"
 #include <cmdlime/errors.h>
 #include "external/sfun/string_utils.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
 #include <functional>
 
 namespace cmdlime::detail{
-namespace str = sfun::string_utils;
 
 template <Format formatType>
 class DefaultParser : public Parser<formatType>
@@ -28,11 +27,11 @@ class DefaultParser : public Parser<formatType>
 
     void process(const std::string& token) override
     {
-        if (str::startsWith(token, "--") && token.size() > 2){
-            const auto flagName = str::after(token, "--");
+        if (sfun::startsWith(token, "--") && token.size() > 2){
+            const auto flagName = sfun::after(token, "--");
             this->readFlag(flagName);
         }
-        else if (str::startsWith(token, "-") && token.size() > 1){
+        else if (sfun::startsWith(token, "-") && token.size() > 1){
             if (isNumber(token)){
                 this->readArg(token);
                 return;
@@ -41,8 +40,8 @@ class DefaultParser : public Parser<formatType>
             if (token.find('=') == std::string::npos)
                 throw ParsingError{"Wrong parameter format: " + token + ". Parameter must have a form of -name=value"};
 
-            const auto paramName = str::before(str::after(token, "-"), "=");
-            const auto paramValue = std::string{str::after(token, "=")};
+            const auto paramName = sfun::before(sfun::after(token, "-"), "=");
+            const auto paramValue = std::string{sfun::after(token, "=")};
             this->readParam(paramName, paramValue);
         }
         else

--- a/include/cmdlime/detail/simpleformat.h
+++ b/include/cmdlime/detail/simpleformat.h
@@ -1,23 +1,22 @@
 #ifndef CMDLIME_SIMPLEFORMAT_H
 #define CMDLIME_SIMPLEFORMAT_H
 
-#include "parser.h"
 #include "formatcfg.h"
 #include "nameutils.h"
+#include "parser.h"
 #include "utils.h"
-#include <cmdlime/errors.h>
-#include "external/sfun/string_utils.h"
 #include "external/sfun/contract.h"
+#include "external/sfun/string_utils.h"
+#include <cmdlime/errors.h>
 #include <algorithm>
-#include <sstream>
-#include <iomanip>
 #include <functional>
+#include <iomanip>
+#include <sstream>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <Format formatType>
-class DefaultParser : public Parser<formatType>
-{
+template<Format formatType>
+class DefaultParser : public Parser<formatType> {
     using Parser<formatType>::Parser;
 
     void preProcess() override
@@ -27,12 +26,12 @@ class DefaultParser : public Parser<formatType>
 
     void process(const std::string& token) override
     {
-        if (sfun::startsWith(token, "--") && token.size() > 2){
+        if (sfun::startsWith(token, "--") && token.size() > 2) {
             const auto flagName = sfun::after(token, "--");
             this->readFlag(flagName);
         }
-        else if (sfun::startsWith(token, "-") && token.size() > 1){
-            if (isNumber(token)){
+        else if (sfun::startsWith(token, "-") && token.size() > 1) {
+            if (isNumber(token)) {
                 this->readArg(token);
                 return;
             }
@@ -50,28 +49,41 @@ class DefaultParser : public Parser<formatType>
 
     void checkNames()
     {
-        auto check = [](const OptionInfo& var, const std::string& varType){
+        auto check = [](const OptionInfo& var, const std::string& varType)
+        {
             if (!std::isalpha(var.name().front()))
                 throw ConfigError{varType + "'s name '" + var.name() + "' must start with an alphabet character"};
-            if (var.name().size() > 1){
-                auto nonAlphaNumCharIt = std::find_if(var.name().begin() + 1, var.name().end(), [](char ch){return !std::isalnum(ch);});
+            if (var.name().size() > 1) {
+                auto nonAlphaNumCharIt = std::find_if(
+                        var.name().begin() + 1,
+                        var.name().end(),
+                        [](char ch)
+                        {
+                            return !std::isalnum(ch);
+                        });
                 if (nonAlphaNumCharIt != var.name().end())
                     throw ConfigError{varType + "'s name '" + var.name() + "' must consist of alphanumeric characters"};
             }
         };
-        this->forEachParamInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachParamListInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachFlagInfo([check](const OptionInfo& var){
-            check(var, "Flag");
-        });
+        this->forEachParamInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachParamListInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachFlagInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Flag");
+                });
     }
 };
 
-class DefaultNameProvider{
+class DefaultNameProvider {
 public:
     static std::string name(const std::string& optionName)
     {
@@ -96,11 +108,9 @@ public:
         sfunPrecondition(!typeName.empty());
         return toCamelCase(templateType(typeNameWithoutNamespace(typeName)));
     }
-
 };
 
-
-class DefaultOutputFormatter{
+class DefaultOutputFormatter {
 public:
     static std::string paramUsageName(const IParam& param)
     {
@@ -125,16 +135,14 @@ public:
     static std::string paramDescriptionName(const IParam& param, int indent = 0)
     {
         auto stream = std::stringstream{};
-        stream << std::setw(indent) << paramPrefix()
-               << param.info().name() << "=<" << param.info().valueName() << ">";
+        stream << std::setw(indent) << paramPrefix() << param.info().name() << "=<" << param.info().valueName() << ">";
         return stream.str();
     }
 
     static std::string paramListDescriptionName(const IParamList& param, int indent = 0)
     {
         auto stream = std::stringstream{};
-        stream << std::setw(indent) << paramPrefix()
-               << param.info().name() << "=<" << param.info().valueName() << ">";
+        stream << std::setw(indent) << paramPrefix() << param.info().name() << "=<" << param.info().valueName() << ">";
         return stream.str();
     }
 
@@ -196,18 +204,16 @@ public:
         stream << "<" << argList.info().name() << "> (" << argList.info().valueName() << ")";
         return stream.str();
     }
-
 };
 
 template<>
-struct FormatCfg<Format::Simple>
-{
+struct FormatCfg<Format::Simple> {
     using parser = DefaultParser<Format::Simple>;
     using nameProvider = DefaultNameProvider;
     using outputFormatter = DefaultOutputFormatter;
     static constexpr bool shortNamesEnabled = false;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_SIMPLEFORMAT_H

--- a/include/cmdlime/detail/usageinfocreator.h
+++ b/include/cmdlime/detail/usageinfocreator.h
@@ -19,12 +19,11 @@
 #include <iomanip>
 
 namespace cmdlime::detail{
-namespace str = sfun::string_utils;
 
 inline std::string adjustedToLineBreak(std::string line, std::string& text)
 {
     if (!text.empty() && !isspace(text.front())){
-        auto trimmedLine = str::trimFront(line);
+        auto trimmedLine = sfun::trimFront(line);
         if (std::find_if(trimmedLine.begin(), trimmedLine.end(), [](auto ch){return std::isspace(ch);}) == trimmedLine.end())
             return line;
         while(!isspace(line.back())){
@@ -42,7 +41,7 @@ inline std::string popLine(std::string& text, std::size_t width, bool firstLine 
         auto line = text.substr(0, newLinePos);
         text.erase(text.begin(), text.begin() + static_cast<int>(newLinePos + 1));
         if (!firstLine)
-            line = str::trimFront(line);
+            line = sfun::trimFront(line);
         return line;
     }
 
@@ -52,7 +51,7 @@ inline std::string popLine(std::string& text, std::size_t width, bool firstLine 
     else
         text.erase(text.begin(), text.begin() + static_cast<int>(width));
     if (!firstLine)
-        line = str::trimFront(line);
+        line = sfun::trimFront(line);
     return adjustedToLineBreak(line, text);
 }
 

--- a/include/cmdlime/detail/utils.h
+++ b/include/cmdlime/detail/utils.h
@@ -4,12 +4,12 @@
 #include "initializedoptional.h"
 #include "nameof_import.h"
 #include "external/sfun/type_traits.h"
-#include <string>
-#include <sstream>
 #include <optional>
+#include <sstream>
+#include <string>
 #include <tuple>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
 inline std::string capitalize(const std::string& input)
 {
@@ -22,7 +22,8 @@ inline std::string capitalize(const std::string& input)
 
 inline bool isNumber(const std::string& str)
 {
-    auto check = [&str](auto num){
+    auto check = [&str](auto num)
+    {
         std::stringstream stream{str};
         stream >> num;
         return !stream.bad() && !stream.fail() && stream.eof();
@@ -35,8 +36,9 @@ template<typename TCfg>
 inline std::string nameOfType()
 {
     using type = std::remove_const_t<std::remove_reference_t<TCfg>>;
-    auto result = [&]{
-        if constexpr(sfun::is_optional_v<type> || sfun::is_dynamic_sequence_container_v<type>)
+    auto result = [&]
+    {
+        if constexpr (sfun::is_optional_v<type> || sfun::is_dynamic_sequence_container_v<type>)
             return std::string{nameof::nameof_short_type<typename type::value_type>()};
         else
             return std::string{nameof::nameof_short_type<type>()};
@@ -56,6 +58,6 @@ inline std::tuple<std::string, std::string> getMemberPtrNameAndType(TParent* par
 }
 #endif
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_UTILS_H

--- a/include/cmdlime/detail/utils.h
+++ b/include/cmdlime/detail/utils.h
@@ -3,7 +3,7 @@
 
 #include "initializedoptional.h"
 #include "nameof_import.h"
-#include "external/sfun/traits.h"
+#include "external/sfun/type_traits.h"
 #include <string>
 #include <sstream>
 #include <optional>
@@ -36,7 +36,7 @@ inline std::string nameOfType()
 {
     using type = std::remove_const_t<std::remove_reference_t<TCfg>>;
     auto result = [&]{
-        if constexpr(sfun::traits::is_optional_v<type> || sfun::traits::is_dynamic_sequence_container_v<type>)
+        if constexpr(sfun::is_optional_v<type> || sfun::is_dynamic_sequence_container_v<type>)
             return std::string{nameof::nameof_short_type<typename type::value_type>()};
         else
             return std::string{nameof::nameof_short_type<type>()};

--- a/include/cmdlime/detail/validator.h
+++ b/include/cmdlime/detail/validator.h
@@ -5,7 +5,7 @@
 #include "ioption.h"
 #include "optioninfo.h"
 #include "utils.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/utility.h"
 #include <cmdlime/errors.h>
 #include <functional>
 
@@ -23,7 +23,7 @@ inline std::string validatorOptionTypeName(OptionType optionType)
         case OptionType::Param: return "parameter";
         case OptionType::ParamList: return "parameter list";
     }
-    sfun::assert::ensureNotReachable();
+    sfun::unreachable();
 }
 
 template<typename T>

--- a/include/cmdlime/detail/validator.h
+++ b/include/cmdlime/detail/validator.h
@@ -1,8 +1,8 @@
 #ifndef CMDLIME_VALIDATOR_H
 #define CMDLIME_VALIDATOR_H
 
-#include "ivalidator.h"
 #include "ioption.h"
+#include "ivalidator.h"
 #include "optioninfo.h"
 #include "utils.h"
 #include "external/sfun/utility.h"
@@ -13,46 +13,55 @@ namespace cmdlime::detail {
 
 inline std::string validatorOptionTypeName(OptionType optionType)
 {
-    switch(optionType){
-        case OptionType::Arg: return "argument";
-        case OptionType::ArgList: return "argument list";
-        case OptionType::Command: return "command";
-        case OptionType::Subcommand: return "subcommand";
-        case OptionType::Flag: return "flag";
-        case OptionType::ExitFlag: return "exit flag";
-        case OptionType::Param: return "parameter";
-        case OptionType::ParamList: return "parameter list";
+    switch (optionType) {
+    case OptionType::Arg:
+        return "argument";
+    case OptionType::ArgList:
+        return "argument list";
+    case OptionType::Command:
+        return "command";
+    case OptionType::Subcommand:
+        return "subcommand";
+    case OptionType::Flag:
+        return "flag";
+    case OptionType::ExitFlag:
+        return "exit flag";
+    case OptionType::Param:
+        return "parameter";
+    case OptionType::ParamList:
+        return "parameter list";
     }
     sfun::unreachable();
 }
 
 template<typename T>
-class Validator : public IValidator
-{
+class Validator : public IValidator {
 public:
     Validator(IOption& option, T& optionValue, std::function<void(const T&)> validatingFunc)
         : option_(option)
         , optionValue_(optionValue)
         , validatingFunc_(std::move(validatingFunc))
-    {}
+    {
+    }
 
 private:
     void validate(const std::string& commandName) const override
     {
-        auto makeErrorMessage = [&](const auto& message){
-            auto prefix = commandName.empty() ?
-                capitalize(validatorOptionTypeName(option_.type())) :
-                "Command '" + commandName + "'s " + validatorOptionTypeName(option_.type());
+        auto makeErrorMessage = [&](const auto& message)
+        {
+            auto prefix = commandName.empty()
+                    ? capitalize(validatorOptionTypeName(option_.type()))
+                    : "Command '" + commandName + "'s " + validatorOptionTypeName(option_.type());
             return prefix + " '" + option_.info().name() + "' is invalid: " + message;
         };
 
-        try{
+        try {
             validatingFunc_(optionValue_);
         }
-        catch(const ValidationError& e){
+        catch (const ValidationError& e) {
             throw ParsingError{makeErrorMessage(e.what())};
         }
-        catch(...){
+        catch (...) {
             throw ParsingError{makeErrorMessage("Unexpected error")};
         }
     }
@@ -67,6 +76,6 @@ private:
     std::function<void(const T&)> validatingFunc_;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_VALIDATOR_H

--- a/include/cmdlime/detail/x11format.h
+++ b/include/cmdlime/detail/x11format.h
@@ -1,23 +1,22 @@
 #ifndef CMDLIME_X11FORMAT_H
 #define CMDLIME_X11FORMAT_H
 
-#include "parser.h"
-#include "nameutils.h"
-#include "utils.h"
 #include "formatcfg.h"
-#include <cmdlime/errors.h>
-#include "external/sfun/string_utils.h"
+#include "nameutils.h"
+#include "parser.h"
+#include "utils.h"
 #include "external/sfun/contract.h"
+#include "external/sfun/string_utils.h"
+#include <cmdlime/errors.h>
 #include <algorithm>
-#include <sstream>
-#include <iomanip>
 #include <functional>
+#include <iomanip>
+#include <sstream>
 
-namespace cmdlime::detail{
+namespace cmdlime::detail {
 
-template <Format formatType>
-class X11Parser : public Parser<formatType>
-{
+template<Format formatType>
+class X11Parser : public Parser<formatType> {
     using Parser<formatType>::Parser;
 
     void preProcess() override
@@ -28,11 +27,11 @@ class X11Parser : public Parser<formatType>
 
     void process(const std::string& token) override
     {
-        if (!foundParam_.empty()){
+        if (!foundParam_.empty()) {
             this->readParam(foundParam_, token);
             foundParam_.clear();
         }
-        else if (sfun::startsWith(token, "-") && token.size() > 1){
+        else if (sfun::startsWith(token, "-") && token.size() > 1) {
             auto command = sfun::after(token, "-");
             if (isParamOrFlag(command) && !foundParam_.empty())
                 throw ParsingError{"Parameter '-" + foundParam_ + "' value can't be empty"};
@@ -62,38 +61,51 @@ class X11Parser : public Parser<formatType>
     {
         if (cmd.empty())
             return false;
-        return this->findFlag(cmd) ||
-               this->findParam(cmd) ||
-               this->findParamList(cmd);
+        return this->findFlag(cmd) || this->findParam(cmd) || this->findParamList(cmd);
     }
 
     void checkNames()
     {
-        auto check = [](const OptionInfo& var, const std::string& varType){
+        auto check = [](const OptionInfo& var, const std::string& varType)
+        {
             if (!sfun::isalpha(var.name().front()))
                 throw ConfigError{varType + "'s name '" + var.name() + "' must start with an alphabet character"};
-            if (var.name().size() > 1){
-                auto nonSupportedCharIt = std::find_if(var.name().begin() + 1, var.name().end(), [](char ch){return !sfun::isalnum(ch) && ch != '-';});
+            if (var.name().size() > 1) {
+                auto nonSupportedCharIt = std::find_if(
+                        var.name().begin() + 1,
+                        var.name().end(),
+                        [](char ch)
+                        {
+                            return !sfun::isalnum(ch) && ch != '-';
+                        });
                 if (nonSupportedCharIt != var.name().end())
-                    throw ConfigError{varType + "'s name '" + var.name() + "' must consist of alphanumeric characters and hyphens"};
+                    throw ConfigError{
+                            varType + "'s name '" + var.name() +
+                            "' must consist of alphanumeric characters and hyphens"};
             }
         };
-        this->forEachParamInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachParamListInfo([check](const OptionInfo& var){
-            check(var, "Parameter");
-        });
-        this->forEachFlagInfo([check](const OptionInfo& var){
-            check(var, "Flag");
-        });
+        this->forEachParamInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachParamListInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Parameter");
+                });
+        this->forEachFlagInfo(
+                [check](const OptionInfo& var)
+                {
+                    check(var, "Flag");
+                });
     }
 
 private:
     std::string foundParam_;
 };
 
-class X11NameProvider{
+class X11NameProvider {
 public:
     static std::string name(const std::string& optionName)
     {
@@ -120,8 +132,7 @@ public:
     }
 };
 
-
-class X11OutputFormatter{
+class X11OutputFormatter {
 public:
     static std::string paramUsageName(const IParam& param)
     {
@@ -146,16 +157,14 @@ public:
     static std::string paramDescriptionName(const IParam& param, int indent = 0)
     {
         auto stream = std::stringstream{};
-        stream << std::setw(indent) << paramPrefix()
-               << param.info().name() << " <" << param.info().valueName() << ">";
+        stream << std::setw(indent) << paramPrefix() << param.info().name() << " <" << param.info().valueName() << ">";
         return stream.str();
     }
 
     static std::string paramListDescriptionName(const IParamList& param, int indent = 0)
     {
         auto stream = std::stringstream{};
-        stream << std::setw(indent) << paramPrefix()
-               << param.info().name() << " <" << param.info().valueName() << ">";
+        stream << std::setw(indent) << paramPrefix() << param.info().name() << " <" << param.info().valueName() << ">";
         return stream.str();
     }
 
@@ -217,18 +226,16 @@ public:
         stream << "<" << argList.info().name() << "> (" << argList.info().valueName() << ")";
         return stream.str();
     }
-
 };
 
 template<>
-struct FormatCfg<Format::X11>
-{
+struct FormatCfg<Format::X11> {
     using parser = X11Parser<Format::X11>;
     using nameProvider = X11NameProvider;
     using outputFormatter = X11OutputFormatter;
     static constexpr bool shortNamesEnabled = true;
 };
 
-}
+} //namespace cmdlime::detail
 
 #endif //CMDLIME_X11FORMAT_H

--- a/include/cmdlime/detail/x11format.h
+++ b/include/cmdlime/detail/x11format.h
@@ -7,14 +7,13 @@
 #include "formatcfg.h"
 #include <cmdlime/errors.h>
 #include "external/sfun/string_utils.h"
-#include "external/sfun/asserts.h"
+#include "external/sfun/contract.h"
 #include <algorithm>
 #include <sstream>
 #include <iomanip>
 #include <functional>
 
 namespace cmdlime::detail{
-namespace str = sfun::string_utils;
 
 template <Format formatType>
 class X11Parser : public Parser<formatType>
@@ -33,8 +32,8 @@ class X11Parser : public Parser<formatType>
             this->readParam(foundParam_, token);
             foundParam_.clear();
         }
-        else if (str::startsWith(token, "-") && token.size() > 1){
-            auto command = str::after(token, "-");
+        else if (sfun::startsWith(token, "-") && token.size() > 1){
+            auto command = sfun::after(token, "-");
             if (isParamOrFlag(command) && !foundParam_.empty())
                 throw ParsingError{"Parameter '-" + foundParam_ + "' value can't be empty"};
 
@@ -71,10 +70,10 @@ class X11Parser : public Parser<formatType>
     void checkNames()
     {
         auto check = [](const OptionInfo& var, const std::string& varType){
-            if (!str::isalpha(var.name().front()))
+            if (!sfun::isalpha(var.name().front()))
                 throw ConfigError{varType + "'s name '" + var.name() + "' must start with an alphabet character"};
             if (var.name().size() > 1){
-                auto nonSupportedCharIt = std::find_if(var.name().begin() + 1, var.name().end(), [](char ch){return !str::isalnum(ch) && ch != '-';});
+                auto nonSupportedCharIt = std::find_if(var.name().begin() + 1, var.name().end(), [](char ch){return !sfun::isalnum(ch) && ch != '-';});
                 if (nonSupportedCharIt != var.name().end())
                     throw ConfigError{varType + "'s name '" + var.name() + "' must consist of alphanumeric characters and hyphens"};
             }

--- a/include/cmdlime/errors.h
+++ b/include/cmdlime/errors.h
@@ -4,34 +4,27 @@
 #include <stdexcept>
 #include <utility>
 
-namespace cmdlime{
+namespace cmdlime {
 
-class Error : public std::runtime_error
-{
+class Error : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
-class ParsingError : public Error
-{
+class ParsingError : public Error {
     using Error::Error;
 };
 
-class ConfigError : public Error
-{
+class ConfigError : public Error {
     using Error::Error;
 };
 
-class ValidationError : public Error
-{
+class ValidationError : public Error {
     using Error::Error;
 };
 
-class CommandError : public Error
-{
+class CommandError : public Error {
 public:
-    CommandError(std::string commandName,
-                 std::string commandUsageInfo,
-                 const std::string& errorMsg)
+    CommandError(std::string commandName, std::string commandUsageInfo, const std::string& errorMsg)
         : Error(errorMsg)
         , commandName_(std::move(commandName))
         , commandUsageInfo_(std::move(commandUsageInfo))
@@ -53,27 +46,22 @@ private:
     std::string commandUsageInfo_;
 };
 
-class CommandParsingError : public CommandError
-{
+class CommandParsingError : public CommandError {
 public:
-    CommandParsingError(std::string commandName,
-                        std::string commandUsageInfo,
-                        const ParsingError& error)
+    CommandParsingError(std::string commandName, std::string commandUsageInfo, const ParsingError& error)
         : CommandError(std::move(commandName), std::move(commandUsageInfo), error.what())
-    {}
+    {
+    }
 };
 
-
-class CommandConfigError : public CommandError
-{
+class CommandConfigError : public CommandError {
 public:
-    CommandConfigError(std::string commandName,
-                       std::string commandUsageInfo,
-                       const ConfigError& error)
+    CommandConfigError(std::string commandName, std::string commandUsageInfo, const ConfigError& error)
         : CommandError(std::move(commandName), std::move(commandUsageInfo), error.what())
-    {}
+    {
+    }
 };
 
-}
+} //namespace cmdlime
 
 #endif //CMDLIME_ERRORS_H

--- a/include/cmdlime/format.h
+++ b/include/cmdlime/format.h
@@ -11,6 +11,6 @@ enum class Format {
     GNU
 };
 
-}
+} //namespace cmdlime
 
 #endif //CMDLIME_FORMAT_H

--- a/include/cmdlime/stringconverter.h
+++ b/include/cmdlime/stringconverter.h
@@ -1,20 +1,19 @@
 #ifndef CMDLIME_STRINGCONVERTER_H
 #define CMDLIME_STRINGCONVERTER_H
 
-#include "detail/utils.h"
 #include "detail/external/sfun/type_traits.h"
-#include <string>
-#include <sstream>
+#include "detail/utils.h"
 #include <optional>
+#include <sstream>
+#include <string>
 
-
-namespace cmdlime{
+namespace cmdlime {
 
 template<typename T>
-struct StringConverter{
+struct StringConverter {
     static std::optional<std::string> toString(const T& value)
     {
-        if constexpr(sfun::is_optional_v<T>){
+        if constexpr (sfun::is_optional_v<T>) {
             if (!value)
                 return {};
             auto stream = std::stringstream{};
@@ -30,8 +29,7 @@ struct StringConverter{
 
     static std::optional<T> fromString(const std::string& data)
     {
-        [[maybe_unused]]
-        auto setValue = [](auto& value, const std::string& data) -> std::optional<T>
+        [[maybe_unused]] auto setValue = [](auto& value, const std::string& data) -> std::optional<T>
         {
             auto stream = std::stringstream{data};
             stream >> value;
@@ -41,15 +39,15 @@ struct StringConverter{
             return value;
         };
 
-        if constexpr(std::is_convertible_v<sfun::remove_optional_t<T>, std::string>){
+        if constexpr (std::is_convertible_v<sfun::remove_optional_t<T>, std::string>) {
             return data;
         }
-        else if constexpr(sfun::is_optional_v<T>){
+        else if constexpr (sfun::is_optional_v<T>) {
             auto value = T{};
             value.emplace();
             return setValue(*value, data);
         }
-        else{
+        else {
             auto value = T{};
             return setValue(value, data);
         }
@@ -64,7 +62,7 @@ std::optional<std::string> convertToString(const T& value)
     try {
         return StringConverter<T>::toString(value);
     }
-    catch(...){
+    catch (...) {
         return {};
     }
 }
@@ -75,12 +73,12 @@ std::optional<T> convertFromString(const std::string& data)
     try {
         return StringConverter<T>::fromString(data);
     }
-    catch(...){
+    catch (...) {
         return {};
     }
 }
 
-}
-}
+} //namespace detail
+} //namespace cmdlime
 
 #endif //CMDLIME_STRINGCONVERTER_H

--- a/include/cmdlime/stringconverter.h
+++ b/include/cmdlime/stringconverter.h
@@ -2,7 +2,7 @@
 #define CMDLIME_STRINGCONVERTER_H
 
 #include "detail/utils.h"
-#include "detail/external/sfun/traits.h"
+#include "detail/external/sfun/type_traits.h"
 #include <string>
 #include <sstream>
 #include <optional>
@@ -14,7 +14,7 @@ template<typename T>
 struct StringConverter{
     static std::optional<std::string> toString(const T& value)
     {
-        if constexpr(sfun::traits::is_optional_v<T>){
+        if constexpr(sfun::is_optional_v<T>){
             if (!value)
                 return {};
             auto stream = std::stringstream{};
@@ -41,10 +41,10 @@ struct StringConverter{
             return value;
         };
 
-        if constexpr(std::is_convertible_v<sfun::traits::remove_optional_t<T>, std::string>){
+        if constexpr(std::is_convertible_v<sfun::remove_optional_t<T>, std::string>){
             return data;
         }
-        else if constexpr(sfun::traits::is_optional<T>::value){
+        else if constexpr(sfun::is_optional_v<T>){
             auto value = T{};
             value.emplace();
             return setValue(*value, data);

--- a/include/cmdlime/usageinfoformat.h
+++ b/include/cmdlime/usageinfoformat.h
@@ -1,15 +1,15 @@
 #ifndef CMDLIME_USAGEINFOFORMAT_H
 #define CMDLIME_USAGEINFOFORMAT_H
 
-namespace cmdlime{
+namespace cmdlime {
 
-struct UsageInfoFormat{
+struct UsageInfoFormat {
     int terminalWidth = 80;
     int maxNameColumnWidth = 46;
     int columnsSpacing = 4;
     int nameIndentation = 4;
 };
 
-}
+} //namespace cmdlime
 
 #endif //CMDLIME_USAGEINFOFORMAT_H

--- a/tests/assert_exception.h
+++ b/tests/assert_exception.h
@@ -3,16 +3,18 @@
 #include <functional>
 
 template<typename ExceptionType>
-void assert_exception(std::function<void()> throwingCode, std::function<void(const ExceptionType&)> exceptionContentChecker)
+void assert_exception(
+        std::function<void()> throwingCode,
+        std::function<void(const ExceptionType&)> exceptionContentChecker)
 {
-    try{
+    try {
         throwingCode();
         FAIL() << "exception wasn't thrown!";
     }
-    catch(const ExceptionType& e){
+    catch (const ExceptionType& e) {
         exceptionContentChecker(e);
     }
-    catch(...){
+    catch (...) {
         FAIL() << "Unexpected exception was thrown";
     }
 }

--- a/tests/test_gnu_format.cpp
+++ b/tests/test_gnu_format.cpp
@@ -1,24 +1,23 @@
-#include <gtest/gtest.h>
-#include <cmdlime/config.h>
-#include <cmdlime/commandlinereader.h>
 #include "assert_exception.h"
-#include <optional>
+#include <cmdlime/commandlinereader.h>
+#include <cmdlime/config.h>
+#include <gtest/gtest.h>
 #include <list>
+#include <optional>
 
 #if __has_include(<nameof.hpp>)
 #define NAMEOF_AVAILABLE
 #endif
 
-
-namespace test_gnu_format{
+namespace test_gnu_format {
 
 using namespace cmdlime;
 
-struct NestedSubcommandConfig: public Config{
+struct NestedSubcommandConfig : public Config {
     CMDLIME_PARAM(prm, std::string);
 };
 
-struct SubcommandConfig: public Config{
+struct SubcommandConfig : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::ShortName("i");
@@ -30,8 +29,7 @@ struct SubcommandConfig: public Config{
     CMDLIME_COMMAND(nested, NestedSubcommandConfig);
 };
 
-
-struct FullConfig : public Config{
+struct FullConfig : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalParam2, std::optional<std::string>) << cmdlime::WithoutShortName{};
@@ -47,13 +45,14 @@ struct FullConfig : public Config{
 };
 
 #ifdef CMDLIME_NAMEOF_AVAILABLE
-struct FullConfigWithoutMacro : public Config{
-    std::string requiredParam           = param<&T::requiredParam>();
-    std::string optionalParam           = param<&T::optionalParam>()("defaultValue");
+struct FullConfigWithoutMacro : public Config {
+    std::string requiredParam = param<&T::requiredParam>();
+    std::string optionalParam = param<&T::optionalParam>()("defaultValue");
     std::optional<std::string> optionalParam2 = param<&T::optionalParam2>() << cmdlime::WithoutShortName{};
     std::optional<int> optionalIntParam = param<&T::optionalIntParam>()() << cmdlime::ShortName("i");
-    std::vector<std::string> prmList    = paramList<&T::prmList>() << cmdlime::ShortName("L");
-    std::vector<int> optionalPrmList    = paramList<&T::optionalPrmList>()(std::vector<int>{99, 100}) << cmdlime::ShortName("O");
+    std::vector<std::string> prmList = paramList<&T::prmList>() << cmdlime::ShortName("L");
+    std::vector<int> optionalPrmList = paramList<&T::optionalPrmList>()(std::vector<int>{99, 100})
+            << cmdlime::ShortName("O");
     bool flg = flag<&T::flg>();
     double a = arg<&T::a>();
     std::vector<float> aList = argList<&T::aList>();
@@ -64,13 +63,17 @@ private:
     using T = FullConfigWithoutMacro;
 };
 #else
-struct FullConfigWithoutMacro : public Config{
-    std::string requiredParam           = param<&T::requiredParam>("requiredParam", "string");
-    std::string optionalParam           = param<&T::optionalParam>("optionalParam", "string")("defaultValue");
-    std::optional<std::string> optionalParam2 = param<&T::optionalParam2>("optionalParam2", "string") << cmdlime::WithoutShortName{};
-    std::optional<int> optionalIntParam = param<&T::optionalIntParam>("optionalIntParam", "int")() << cmdlime::ShortName("i");
-    std::vector<std::string> prmList    = paramList<&T::prmList>("prmList", "string") << cmdlime::ShortName("L");
-    std::vector<int> optionalPrmList    = paramList<&T::optionalPrmList>("optionalPrmList", "int")(std::vector<int>{99, 100}) << cmdlime::ShortName("O");
+struct FullConfigWithoutMacro : public Config {
+    std::string requiredParam = param<&T::requiredParam>("requiredParam", "string");
+    std::string optionalParam = param<&T::optionalParam>("optionalParam", "string")("defaultValue");
+    std::optional<std::string> optionalParam2 = param<&T::optionalParam2>("optionalParam2", "string")
+            << cmdlime::WithoutShortName{};
+    std::optional<int> optionalIntParam = param<&T::optionalIntParam>("optionalIntParam", "int")()
+            << cmdlime::ShortName("i");
+    std::vector<std::string> prmList = paramList<&T::prmList>("prmList", "string") << cmdlime::ShortName("L");
+    std::vector<int> optionalPrmList =
+            paramList<&T::optionalPrmList>("optionalPrmList", "int")(std::vector<int>{99, 100})
+            << cmdlime::ShortName("O");
     bool flg = flag<&T::flg>("flg");
     double a = arg<&T::a>("a", "double");
     std::vector<float> aList = argList<&T::aList>("aList", "float");
@@ -82,19 +85,19 @@ private:
 };
 #endif
 
-class IConfig{
+class IConfig {
 public:
     virtual ~IConfig() = default;
 };
 
-struct NonAggregateSubCommandCfg : public Config, public IConfig
-{
+struct NonAggregateSubCommandCfg : public Config,
+                                   public IConfig {
     using Config::Config;
     CMDLIME_PARAM(prm, std::string);
 };
 
-struct NonAggregateConfig : public Config, public IConfig
-{
+struct NonAggregateConfig : public Config,
+                            public IConfig {
     using Config::Config;
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_COMMAND(cmd, NonAggregateSubCommandCfg);
@@ -104,8 +107,23 @@ TEST(GNUConfig, AllSet)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     auto cfg = reader.read<FullConfig>(
-            {"-r", "FOO", "-oBAR", "--optional-param2", "Hello world", "--optional-int-param", "-9", "-L", "zero", "-L", "one",
-             "--optional-param-list=1,2", "-f", "4.2", "1.1", "2.2", "3.3"});
+            {"-r",
+             "FOO",
+             "-oBAR",
+             "--optional-param2",
+             "Hello world",
+             "--optional-int-param",
+             "-9",
+             "-L",
+             "zero",
+             "-L",
+             "one",
+             "--optional-param-list=1,2",
+             "-f",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     ASSERT_TRUE(cfg.optionalParam2.has_value());
@@ -124,8 +142,21 @@ TEST(GNUConfig, AllSetWithoutMacro)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     auto cfg = reader.read<FullConfigWithoutMacro>(
-            {"-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-             "--optional-prm-list=1,2", "-f", "4.2", "1.1", "2.2", "3.3"});
+            {"-r",
+             "FOO",
+             "-oBAR",
+             "--optional-int-param",
+             "9",
+             "-L",
+             "zero",
+             "-L",
+             "one",
+             "--optional-prm-list=1,2",
+             "-f",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.optionalIntParam, 9);
@@ -141,10 +172,27 @@ TEST(GNUConfig, AllSetWithoutMacro)
 TEST(GNUConfig, AllSetInSubCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<FullConfig>({"-r", "FOO", "--prm-list=zero", "--prm-list=one", "4.2", "1.1",
-                                           "subcommand", "--required-param", "FOO", "--optional-param=BAR",
-                                           "--optional-int-param", "9", "--prm-list=zero", "--prm-list=one",
-                                           "--optional-param-list=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+    auto cfg = reader.read<FullConfig>(
+            {"-r",
+             "FOO",
+             "--prm-list=zero",
+             "--prm-list=one",
+             "4.2",
+             "1.1",
+             "subcommand",
+             "--required-param",
+             "FOO",
+             "--optional-param=BAR",
+             "--optional-int-param",
+             "9",
+             "--prm-list=zero",
+             "--prm-list=one",
+             "--optional-param-list=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
@@ -168,12 +216,27 @@ TEST(GNUConfig, AllSetInSubCommand)
 TEST(GNUConfig, AllSetInSubCommandWithoutMacro)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<FullConfigWithoutMacro>({"-r", "FOO", "--prm-list=zero", "--prm-list=one", "4.2", "1.1",
-                                                       "subcommand", "--required-param", "FOO", "--optional-param=BAR",
-                                                       "--optional-int-param", "9", "--prm-list=zero",
-                                                       "--prm-list=one",
-                                                       "--optional-param-list=1,2", "--flg", "4.2", "1.1", "2.2",
-                                                       "3.3"});
+    auto cfg = reader.read<FullConfigWithoutMacro>(
+            {"-r",
+             "FOO",
+             "--prm-list=zero",
+             "--prm-list=one",
+             "4.2",
+             "1.1",
+             "subcommand",
+             "--required-param",
+             "FOO",
+             "--optional-param=BAR",
+             "--optional-int-param",
+             "9",
+             "--prm-list=zero",
+             "--prm-list=one",
+             "--optional-param-list=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
@@ -198,9 +261,18 @@ TEST(GNUConfig, AllSetInCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     auto cfg = reader.read<FullConfig>(
-            {"cmd", "--required-param=FOO", "--optional-param=BAR", "--optional-int-param=9", "--prm-list=zero",
+            {"cmd",
+             "--required-param=FOO",
+             "--optional-param=BAR",
+             "--optional-int-param=9",
+             "--prm-list=zero",
              "--prm-list=one",
-             "--optional-param-list=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+             "--optional-param-list=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_FALSE(cfg.subcommand);
     ASSERT_TRUE(cfg.cmd);
     EXPECT_EQ(cfg.cmd->requiredParam, std::string{"FOO"});
@@ -217,9 +289,20 @@ TEST(GNUConfig, AllSetInCommandWithoutMacro)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     auto cfg = reader.read<FullConfigWithoutMacro>(
-            {"cmd", "--required-param", "FOO", "--optional-param=BAR", "--optional-int-param", "9", "--prm-list=zero",
+            {"cmd",
+             "--required-param",
+             "FOO",
+             "--optional-param=BAR",
+             "--optional-int-param",
+             "9",
+             "--prm-list=zero",
              "--prm-list=one",
-             "--optional-param-list=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+             "--optional-param-list=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_FALSE(cfg.subcommand);
     ASSERT_TRUE(cfg.cmd);
     EXPECT_EQ(cfg.cmd->requiredParam, std::string{"FOO"});
@@ -232,10 +315,9 @@ TEST(GNUConfig, AllSetInCommandWithoutMacro)
     EXPECT_EQ(cfg.cmd->argumentList, (std::vector<float>{1.1f, 2.2f, 3.3f}));
 }
 
-
 TEST(GNUConfig, CombinedFlagsAndParams)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_FLAG(firstFlag) << cmdlime::ShortName("f");
         CMDLIME_FLAG(secondFlag) << cmdlime::ShortName("s");
         CMDLIME_FLAG(thirdFlag) << cmdlime::ShortName("t");
@@ -243,45 +325,48 @@ TEST(GNUConfig, CombinedFlagsAndParams)
     };
 
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<Cfg>({"-fst", "-pfirst"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, true);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        auto cfg = reader.read<Cfg>({"-fst", "-pfirst"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, true);
+        EXPECT_EQ(cfg.prm, "first");
     }
 
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<Cfg>({"-tfspfirst"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, true);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        auto cfg = reader.read<Cfg>({"-tfspfirst"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, true);
+        EXPECT_EQ(cfg.prm, "first");
     }
 
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<Cfg>({"-fs", "-tp" "first"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, true);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        auto cfg = reader.read<Cfg>(
+                {"-fs",
+                 "-tp"
+                 "first"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, true);
+        EXPECT_EQ(cfg.prm, "first");
     }
 
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<Cfg>({"-fs", "--prm", "first"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, false);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        auto cfg = reader.read<Cfg>({"-fs", "--prm", "first"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, false);
+        EXPECT_EQ(cfg.prm, "first");
     }
 }
 
 TEST(GNUConfig, NumericParamsAndFlags)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_FLAG(flg) << cmdlime::ShortName("1");
         CMDLIME_PARAM(prm, std::string) << cmdlime::ShortName("2");
         CMDLIME_PARAM(paramSecond, std::string)("default") << cmdlime::ShortName("p");
@@ -321,38 +406,60 @@ TEST(GNUConfig, MissingOptionals)
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_EQ(cfg.optionalIntParam.has_value(), false);
     EXPECT_EQ(cfg.prmList, (std::vector<std::string>{"zero"}));
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 4.2);
     EXPECT_EQ(cfg.argumentList, (std::vector<float>{1.1f, 2.2f, 3.3f}));
 }
 
-
 TEST(GNUConfig, MissingParamAllSetInSubCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"subcommand", "--required-param=FOO", "--optional-param=BAR", "--optional-int-param=9", "--prm-list",
-                 "zero", "--prm-list=one",
-                 "--optional-param-list=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--required-param' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"subcommand",
+                         "--required-param=FOO",
+                         "--optional-param=BAR",
+                         "--optional-int-param=9",
+                         "--prm-list",
+                         "zero",
+                         "--prm-list=one",
+                         "--optional-param-list=1,2",
+                         "--flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--required-param' is missing."});
+            });
 }
 
 TEST(GNUConfig, MissingParamAllSetInCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     auto cfg = reader.read<FullConfig>(
-            {"cmd", "--required-param=FOO", "--optional-param=BAR", "--optional-int-param=9", "--prm-list=zero",
+            {"cmd",
+             "--required-param=FOO",
+             "--optional-param=BAR",
+             "--optional-int-param=9",
+             "--prm-list=zero",
              "--prm-list=one",
-             "--optional-param-list=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+             "--optional-param-list=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_TRUE(cfg.requiredParam.empty());
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -375,7 +482,7 @@ TEST(GNUConfig, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -384,7 +491,7 @@ TEST(GNUConfig, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.cmd->optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.cmd->optionalIntParam.has_value());
     EXPECT_TRUE(cfg.cmd->prmList.empty());
-    EXPECT_EQ(cfg.cmd->optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.cmd->optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.cmd->flg, false);
     EXPECT_EQ(cfg.cmd->argument, 0.f);
     EXPECT_TRUE(cfg.cmd->argumentList.empty());
@@ -392,7 +499,7 @@ TEST(GNUConfig, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.cmd->nested->prm, "FOO");
 }
 
-struct FullConfigWithOptionalArgList : public Config{
+struct FullConfigWithOptionalArgList : public Config {
     CMDLIME_PARAM(requiredParam, std::string) << cmdlime::ShortName("r");
     CMDLIME_PARAM(optionalParam, std::string)({"defaultValue"}) << cmdlime::ShortName("o");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::ShortName("i");
@@ -432,118 +539,179 @@ TEST(GNUConfig, MissingParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-o", "FOO", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--required-param' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>({"-o", "FOO", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--required-param' is missing."});
+            });
 }
 
 TEST(GNUConfig, MissingArg)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfigWithOptionalArgList>({"-r", "FOO", "-o", "BAR", "-i", "9", "-f"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'argument' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfigWithOptionalArgList>({"-r", "FOO", "-o", "BAR", "-i", "9", "-f"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'argument' is missing."});
+            });
 }
 
 TEST(GNUConfig, MissingArgList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'argument-list' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>({"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'argument-list' is missing."});
+            });
 }
 
 TEST(GNUConfig, MissingParamList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "9", "-f", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--prm-list' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-i", "9", "-f", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--prm-list' is missing."});
+            });
 }
 
 TEST(GNUConfig, UnexpectedParam)
 {
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "--test", "TEST", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '--test'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<FullConfig>(
+                            {"-r", "FOO", "--test", "TEST", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '--test'"});
+                });
     }
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-r", "FOO", "-t", "TEST", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<FullConfig>(
+                            {"-r", "FOO", "-t", "TEST", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
+                });
     }
 }
 
 TEST(GNUConfig, UnexpectedFlag)
 {
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-r", "FOO", "--test", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '--test'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg =
+                            reader.read<FullConfig>({"-r", "FOO", "--test", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '--test'"});
+                });
     }
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-r", "FOO", "-t", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<FullConfig>({"-r", "FOO", "-t", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
+                });
     }
 }
 
 TEST(GNUConfig, UnexpectedArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::ShortName("p");
     };
 
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-p", "FOO", "4.2", "1"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '4.2'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-p", "FOO", "4.2", "1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '4.2'"});
+            });
 }
 
 TEST(GNUConfig, WrongParamType)
 {
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "nine", "-L", "zero", "-f", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '--optional-int-param' value from 'nine'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<FullConfig>(
+                            {"-r", "FOO", "-o", "BAR", "-i", "nine", "-L", "zero", "-f", "4.2", "1.1", "2.2", "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(
+                            std::string{error.what()},
+                            std::string{"Couldn't set parameter '--optional-int-param' value from 'nine'"});
+                });
     }
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "--optional-int-param", "nine", "-L", "zero", "-f", "4.2", "1.1", "2.2",
-                 "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '--optional-int-param' value from 'nine'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<FullConfig>(
+                            {"-r",
+                             "FOO",
+                             "-o",
+                             "BAR",
+                             "--optional-int-param",
+                             "nine",
+                             "-L",
+                             "zero",
+                             "-f",
+                             "4.2",
+                             "1.1",
+                             "2.2",
+                             "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(
+                            std::string{error.what()},
+                            std::string{"Couldn't set parameter '--optional-int-param' value from 'nine'"});
+                });
     }
 }
 
@@ -552,123 +720,192 @@ TEST(GNUConfig, WrongParamListElementType)
     {
         auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
         assert_exception<cmdlime::ParsingError>(
-                    [&]{auto cfg = reader.read<FullConfig>(
-                            {"-r", "FOO", "-o", "BAR", "-L", "zero", "-O", "not-int", "-f", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '--optional-param-list' value from 'not-int'"});
-        });
+                [&]
+                {
+                    auto cfg = reader.read<FullConfig>(
+                            {"-r",
+                             "FOO",
+                             "-o",
+                             "BAR",
+                             "-L",
+                             "zero",
+                             "-O",
+                             "not-int",
+                             "-f",
+                             "4.2",
+                             "1.1",
+                             "2.2",
+                             "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(
+                            std::string{error.what()},
+                            std::string{"Couldn't set parameter '--optional-param-list' value from 'not-int'"});
+                });
     }
     {
         auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
         assert_exception<cmdlime::ParsingError>(
-                    [&]{auto cfg = reader.read<FullConfig>(
-                            {"-r", "FOO", "-o", "BAR", "-L", "zero", "--optional-param-list=not-int", "-f", "4.2",
-                             "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '--optional-param-list' value from 'not-int'"});
-        });
+                [&]
+                {
+                    auto cfg = reader.read<FullConfig>(
+                            {"-r",
+                             "FOO",
+                             "-o",
+                             "BAR",
+                             "-L",
+                             "zero",
+                             "--optional-param-list=not-int",
+                             "-f",
+                             "4.2",
+                             "1.1",
+                             "2.2",
+                             "3.3"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(
+                            std::string{error.what()},
+                            std::string{"Couldn't set parameter '--optional-param-list' value from 'not-int'"});
+                });
     }
 }
 
 TEST(GNUConfig, WrongArgType)
 {
-   auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "fortytwo", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "fortytwo", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
+            });
 }
 
 TEST(GNUConfig, WrongArgListElementType)
 {
-   auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2", "1.1", "2.2", "three"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set argument list 'argument-list' element's value from 'three'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2", "1.1", "2.2", "three"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument list 'argument-list' element's value from 'three'"});
+            });
 }
 
 TEST(GNUConfig, ParamEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::ShortName("p");
         CMDLIME_FLAG(flg) << cmdlime::ShortName("f");
     };
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-p"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<Cfg>({"-p"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
+                });
     }
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"--prm"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--prm' value can't be empty"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<Cfg>({"--prm"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--prm' value can't be empty"});
+                });
     }
 }
 
 TEST(GNUConfig, ParamListEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAMLIST(params, std::vector<std::string>) << cmdlime::ShortName("p");
     };
     {
         auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
         assert_exception<cmdlime::ParsingError>(
-                    [&]{auto cfg = reader.read<Cfg>({"-p"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
-        });
+                [&]
+                {
+                    auto cfg = reader.read<Cfg>({"-p"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
+                });
     }
     {
         auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
         assert_exception<cmdlime::ParsingError>(
-            [&]{auto cfg = reader.read<Cfg>({"--params"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--params' value can't be empty"});
-            });
+                [&]
+                {
+                    auto cfg = reader.read<Cfg>({"--params"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--params' value can't be empty"});
+                });
     }
 }
 
 TEST(GNUConfig, ArgEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARG(argument, std::string);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({""});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' value can't be empty"});
+            });
 }
 
 TEST(GNUConfig, ArgListEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARGLIST(args, std::vector<std::string>);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"foo", ""});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'args' element value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"foo", ""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'args' element value can't be empty"});
+            });
 }
-
 
 TEST(GNUConfig, ValuesWithWhitespace)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::ShortName("p");
         CMDLIME_PARAMLIST(prmList, std::list<std::string>) << cmdlime::ShortName("L");
         CMDLIME_ARG(argument, std::string);
@@ -694,59 +931,83 @@ TEST(GNUConfig, ValuesWithWhitespace)
 
 TEST(GNUConfig, ParamWrongNameNonAlphaFirstChar)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::Name("!param");
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-pname"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name '!param' must start with an alphabet character"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-pname"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name '!param' must start with an alphabet character"});
+            });
 }
 
 TEST(GNUConfig, ParamWrongNameNonAlphanum)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::Name("p$r$m");
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-pname"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'p$r$m' must consist of alphanumeric characters and hyphens"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-pname"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name 'p$r$m' must consist of alphanumeric characters and hyphens"});
+            });
 }
 
 TEST(GNUConfig, ParamWrongShortNameTooLong)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(parameter, std::string) << cmdlime::ShortName("prm");
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-pname"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's short name 'prm' can't have more than one symbol"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-pname"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's short name 'prm' can't have more than one symbol"});
+            });
 }
 
 TEST(GNUConfig, ParamWrongShortNameNonAlphanum)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::ShortName("$");
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-pname"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's short name '$' must be an alphanumeric character"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-pname"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's short name '$' must be an alphanumeric character"});
+            });
 }
 
 TEST(GNUConfig, NegativeNumberToArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARG(argument, int);
         CMDLIME_ARG(argumentStr, std::string);
         CMDLIME_ARGLIST(argumentList, std::vector<double>);
@@ -760,20 +1021,24 @@ TEST(GNUConfig, NegativeNumberToArg)
 
 TEST(GNUConfig, NegativeNumberWithoutArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, int) << cmdlime::ShortName("p");
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<Cfg>({"-2"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '-2'"});
-        });
+            [&]
+            {
+                reader.read<Cfg>({"-2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '-2'"});
+            });
 }
 
 TEST(GNUConfig, ArgsDelimiter)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, int) << cmdlime::ShortName("p");
         CMDLIME_PARAM(optionalParam, int)(0) << cmdlime::ShortName("o");
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
@@ -797,7 +1062,7 @@ TEST(GNUConfig, ArgsDelimiter)
 
 TEST(GNUConfig, ArgsDelimiterFront)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(optionalParam, int)(0) << cmdlime::ShortName("o");
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
     };
@@ -810,7 +1075,7 @@ TEST(GNUConfig, ArgsDelimiterFront)
 
 TEST(GNUConfig, ArgsDelimiterBack)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(optionalParam, int)(0) << cmdlime::ShortName("o");
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
     };
@@ -823,7 +1088,7 @@ TEST(GNUConfig, ArgsDelimiterBack)
 
 TEST(GNUConfig, PascalNames)
 {
-    struct PascalConfig : public Config{
+    struct PascalConfig : public Config {
         CMDLIME_PARAM(RequiredParam, std::string);
         CMDLIME_PARAM(OptionalParam, std::string)("defaultValue");
         CMDLIME_PARAM(IntParamOptional, std::optional<int>)();
@@ -835,9 +1100,24 @@ TEST(GNUConfig, PascalNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     auto cfg = reader.read<PascalConfig>(
-            {"--required-param", "FOO", "--optional-param", "BAR", "--int-param-optional", "9", "--list-of-param",
-             "zero", "--list-of-param", "one",
-             "--my-list-of-param-optional", "1", "--my-list-of-param-optional", "2", "--flg", "4.2", "1.1", "2.2",
+            {"--required-param",
+             "FOO",
+             "--optional-param",
+             "BAR",
+             "--int-param-optional",
+             "9",
+             "--list-of-param",
+             "zero",
+             "--list-of-param",
+             "one",
+             "--my-list-of-param-optional",
+             "1",
+             "--my-list-of-param-optional",
+             "2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
              "3.3"});
     EXPECT_EQ(cfg.RequiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.OptionalParam, std::string{"BAR"});
@@ -851,12 +1131,13 @@ TEST(GNUConfig, PascalNames)
 
 TEST(GNUConfig, CustomNamesWithoutShortName)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(requiredParam, std::string) << cmdlime::WithoutShortName{};
         CMDLIME_PARAM(optionalParam, std::string)("defaultValue") << cmdlime::WithoutShortName{};
         CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::WithoutShortName{};
         CMDLIME_PARAMLIST(prmList, std::vector<std::string>) << cmdlime::WithoutShortName{};
-        CMDLIME_PARAMLIST(optionalParamList, std::vector<int>)(std::vector<int>{99, 100}) << cmdlime::WithoutShortName{};
+        CMDLIME_PARAMLIST(optionalParamList, std::vector<int>)
+        (std::vector<int>{99, 100}) << cmdlime::WithoutShortName{};
         CMDLIME_FLAG(flg) << cmdlime::WithoutShortName{};
         CMDLIME_FLAG(secondFlag);
         CMDLIME_ARG(argument, double);
@@ -864,160 +1145,208 @@ TEST(GNUConfig, CustomNamesWithoutShortName)
     };
 
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<TestConfig>(
-            {"--required-param", "FOO", "--optional-param", "BAR", "--optional-int-param", "9", "--prm-list", "zero",
-             "--prm-list", "one",
-             "--flg", "4.2", "1.1", "2.2", "3.3"});
-    EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
-    EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
-    EXPECT_EQ(cfg.optionalIntParam, 9);
-    EXPECT_EQ(cfg.prmList, (std::vector<std::string>{"zero", "one"}));
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
-    EXPECT_EQ(cfg.flg, true);
-    EXPECT_EQ(cfg.secondFlag, false);
-    EXPECT_EQ(cfg.argument, 4.2);
-    EXPECT_EQ(cfg.argumentList, (std::vector<float>{1.1f, 2.2f, 3.3f}));
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        auto cfg = reader.read<TestConfig>(
+                {"--required-param",
+                 "FOO",
+                 "--optional-param",
+                 "BAR",
+                 "--optional-int-param",
+                 "9",
+                 "--prm-list",
+                 "zero",
+                 "--prm-list",
+                 "one",
+                 "--flg",
+                 "4.2",
+                 "1.1",
+                 "2.2",
+                 "3.3"});
+        EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
+        EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
+        EXPECT_EQ(cfg.optionalIntParam, 9);
+        EXPECT_EQ(cfg.prmList, (std::vector<std::string>{"zero", "one"}));
+        EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
+        EXPECT_EQ(cfg.flg, true);
+        EXPECT_EQ(cfg.secondFlag, false);
+        EXPECT_EQ(cfg.argument, 4.2);
+        EXPECT_EQ(cfg.argumentList, (std::vector<float>{1.1f, 2.2f, 3.3f}));
     }
 
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({"-r"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-r'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<TestConfig>({"-r"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-r'"});
+                });
     }
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({"-o"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-o'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<TestConfig>({"-o"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-o'"});
+                });
     }
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({"-f"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-f'"});
-        });
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        assert_exception<cmdlime::ParsingError>(
+                [&]
+                {
+                    auto cfg = reader.read<TestConfig>({"-f"});
+                },
+                [](const cmdlime::ParsingError& error)
+                {
+                    EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-f'"});
+                });
     }
     {
-    auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    reader.setProgramName("testproc");
-    auto expectedDetailedInfo = std::string{
-    "Usage: testproc <argument> --required-param <string> --prm-list <string>... [params] [flags] <argument-list...>\n"
-    "Arguments:\n"
-    "    <argument> (double)               \n"
-    "    <argument-list> (float)           multi-value\n"
-    "Parameters:\n"
-    "       --required-param <string>      \n"
-    "       --prm-list <string>            multi-value\n"
-    "       --optional-param <string>      optional, default: defaultValue\n"
-    "       --optional-int-param <int>     optional\n"
-    "       --optional-param-list <int>    multi-value, optional, default: {99, \n"
-    "                                        100}\n"
-    "Flags:\n"
-    "       --flg                          \n"
-    "   -s, --second-flag                  \n"};
-    EXPECT_EQ(reader.usageInfoDetailed<TestConfig>(), expectedDetailedInfo);
+        auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
+        reader.setProgramName("testproc");
+        auto expectedDetailedInfo =
+                std::string{"Usage: testproc <argument> --required-param <string> --prm-list <string>... [params] "
+                            "[flags] <argument-list...>\n"
+                            "Arguments:\n"
+                            "    <argument> (double)               \n"
+                            "    <argument-list> (float)           multi-value\n"
+                            "Parameters:\n"
+                            "       --required-param <string>      \n"
+                            "       --prm-list <string>            multi-value\n"
+                            "       --optional-param <string>      optional, default: defaultValue\n"
+                            "       --optional-int-param <int>     optional\n"
+                            "       --optional-param-list <int>    multi-value, optional, default: {99, \n"
+                            "                                        100}\n"
+                            "Flags:\n"
+                            "       --flg                          \n"
+                            "   -s, --second-flag                  \n"};
+        EXPECT_EQ(reader.usageInfoDetailed<TestConfig>(), expectedDetailedInfo);
     }
 }
 
 TEST(GNUConfig, CustomNamesMissingParam)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, double) << cmdlime::Name{"P"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--P' is missing."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--P' is missing."});
+            });
 }
 
 TEST(GNUConfig, CustomNamesMissingParamList)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, double) << cmdlime::ShortName{"P"};
         CMDLIME_PARAMLIST(prmList, std::vector<float>) << cmdlime::Name{"L"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({"-P1"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--L' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({"-P1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '--L' is missing."});
+            });
 }
 
 TEST(GNUConfig, CustomNamesMissingArg)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_ARG(argument, double) << cmdlime::Name{"Argument"};
         CMDLIME_ARGLIST(argumentList, std::vector<float>) << cmdlime::Name{"ArgList"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'Argument' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'Argument' is missing."});
+            });
 }
 
 TEST(GNUConfig, CustomNamesMissingArgList)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_ARG(argument, double) << cmdlime::Name{"Argument"};
         CMDLIME_ARGLIST(argumentList, std::vector<float>) << cmdlime::Name{"ArgList"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({"1.0"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'ArgList' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({"1.0"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'ArgList' is missing."});
+            });
 }
 
 TEST(GNUConfig, ConfigErrorRepeatingParamNames)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(Prm, double)();
         CMDLIME_PARAM(prm, int)();
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'prm' is already used."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'prm' is already used."});
+            });
 }
 
 TEST(GNUConfig, ConfigErrorRepeatingParamShortNames)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, double)();
         CMDLIME_PARAMLIST(prmList, std::vector<int>)();
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's short name 'p' is already used."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's short name 'p' is already used."});
+            });
 }
-
 
 TEST(GNUConfig, UsageInfo)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     reader.setProgramName("testproc");
-    auto expectedInfo = std::string{
-    "Usage: testproc [commands] <argument> --required-param <string> --prm-list <string>... "
-    "[--optional-param <string>] [--optional-param2 <string>] [--optional-int-param <int>] [--optional-param-list <int>...] [--flg] [--second-flag] <argument-list...>\n"
-    };
+    auto expectedInfo =
+            std::string{"Usage: testproc [commands] <argument> --required-param <string> --prm-list <string>... "
+                        "[--optional-param <string>] [--optional-param2 <string>] [--optional-int-param <int>] "
+                        "[--optional-param-list <int>...] [--flg] [--second-flag] <argument-list...>\n"};
     EXPECT_EQ(reader.usageInfo<FullConfig>(), expectedInfo);
 }
 
@@ -1025,10 +1354,9 @@ TEST(GNUConfig, UsageInfoWithoutMacro)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     reader.setProgramName("testproc");
-    auto expectedInfo = std::string{
-            "Usage: testproc [commands] <a> --required-param <string> --prm-list <string>... "
-            "[--optional-param <string>] [--optional-param2 <string>] [--optional-int-param <int>] [--optional-prm-list <int>...] [--flg] <a-list...>\n"
-    };
+    auto expectedInfo = std::string{"Usage: testproc [commands] <a> --required-param <string> --prm-list <string>... "
+                                    "[--optional-param <string>] [--optional-param2 <string>] [--optional-int-param "
+                                    "<int>] [--optional-prm-list <int>...] [--flg] <a-list...>\n"};
     EXPECT_EQ(reader.usageInfo<FullConfigWithoutMacro>(), expectedInfo);
 }
 
@@ -1036,25 +1364,26 @@ TEST(GNUConfig, DetailedUsageInfo)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     reader.setProgramName("testproc");
-    auto expectedDetailedInfo = std::string{
-    "Usage: testproc [commands] <argument> --required-param <string> --prm-list <string>... [params] [flags] <argument-list...>\n"
-    "Arguments:\n"
-    "    <argument> (double)               \n"
-    "    <argument-list> (float)           multi-value\n"
-    "Parameters:\n"
-    "   -r, --required-param <string>      \n"
-    "   -L, --prm-list <string>            multi-value\n"
-    "   -o, --optional-param <string>      optional, default: defaultValue\n"
-    "       --optional-param2 <string>     optional\n"
-    "   -i, --optional-int-param <int>     optional\n"
-    "   -O, --optional-param-list <int>    multi-value, optional, default: {99, \n"
-    "                                        100}\n"
-    "Flags:\n"
-    "   -f, --flg                          \n"
-    "       --second-flag                  \n"
-    "Commands:\n"
-    "    cmd [options]                     \n"
-    "    subcommand [options]              \n"};
+    auto expectedDetailedInfo =
+            std::string{"Usage: testproc [commands] <argument> --required-param <string> --prm-list <string>... "
+                        "[params] [flags] <argument-list...>\n"
+                        "Arguments:\n"
+                        "    <argument> (double)               \n"
+                        "    <argument-list> (float)           multi-value\n"
+                        "Parameters:\n"
+                        "   -r, --required-param <string>      \n"
+                        "   -L, --prm-list <string>            multi-value\n"
+                        "   -o, --optional-param <string>      optional, default: defaultValue\n"
+                        "       --optional-param2 <string>     optional\n"
+                        "   -i, --optional-int-param <int>     optional\n"
+                        "   -O, --optional-param-list <int>    multi-value, optional, default: {99, \n"
+                        "                                        100}\n"
+                        "Flags:\n"
+                        "   -f, --flg                          \n"
+                        "       --second-flag                  \n"
+                        "Commands:\n"
+                        "    cmd [options]                     \n"
+                        "    subcommand [options]              \n"};
     EXPECT_EQ(reader.usageInfoDetailed<FullConfig>(), expectedDetailedInfo);
 }
 
@@ -1062,30 +1391,31 @@ TEST(GNUConfig, DetailedUsageInfoWithoutMacro)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     reader.setProgramName("testproc");
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc [commands] <a> --required-param <string> --prm-list <string>... [params] [flags] <a-list...>\n"
-            "Arguments:\n"
-            "    <a> (double)                      \n"
-            "    <a-list> (float)                  multi-value\n"
-            "Parameters:\n"
-            "   -r, --required-param <string>      \n"
-            "   -L, --prm-list <string>            multi-value\n"
-            "   -o, --optional-param <string>      optional, default: defaultValue\n"
-            "       --optional-param2 <string>     optional\n"
-            "   -i, --optional-int-param <int>     optional\n"
-            "   -O, --optional-prm-list <int>      multi-value, optional, default: {99, \n"
-            "                                        100}\n"
-            "Flags:\n"
-            "   -f, --flg                          \n"
-            "Commands:\n"
-            "    cmd [options]                     \n"
-            "    subcommand [options]              \n"};
+    auto expectedDetailedInfo =
+            std::string{"Usage: testproc [commands] <a> --required-param <string> --prm-list <string>... [params] "
+                        "[flags] <a-list...>\n"
+                        "Arguments:\n"
+                        "    <a> (double)                      \n"
+                        "    <a-list> (float)                  multi-value\n"
+                        "Parameters:\n"
+                        "   -r, --required-param <string>      \n"
+                        "   -L, --prm-list <string>            multi-value\n"
+                        "   -o, --optional-param <string>      optional, default: defaultValue\n"
+                        "       --optional-param2 <string>     optional\n"
+                        "   -i, --optional-int-param <int>     optional\n"
+                        "   -O, --optional-prm-list <int>      multi-value, optional, default: {99, \n"
+                        "                                        100}\n"
+                        "Flags:\n"
+                        "   -f, --flg                          \n"
+                        "Commands:\n"
+                        "    cmd [options]                     \n"
+                        "    subcommand [options]              \n"};
     EXPECT_EQ(reader.usageInfoDetailed<FullConfigWithoutMacro>(), expectedDetailedInfo);
 }
 
-
-TEST(GNUConfig, WrongParamsWithExitFlag){
-    struct ConfigWithExitFlag : public Config{
+TEST(GNUConfig, WrongParamsWithExitFlag)
+{
+    struct ConfigWithExitFlag : public Config {
         CMDLIME_PARAM(requiredParam, int);
         CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
         CMDLIME_FLAG(flg);
@@ -1099,9 +1429,15 @@ TEST(GNUConfig, WrongParamsWithExitFlag){
     EXPECT_EQ(cfg.exitFlg, true);
 }
 
-TEST(GNUConfig, InvalidParamsWithExitFlag){
-    struct ConfigWithExitFlag : public Config{
-        CMDLIME_PARAM(requiredParam, int)(0) << [](int val){ if (val < 1) throw cmdlime::ValidationError("Value must be greater than 0"); };
+TEST(GNUConfig, InvalidParamsWithExitFlag)
+{
+    struct ConfigWithExitFlag : public Config {
+        CMDLIME_PARAM(requiredParam, int)
+        (0) << [](int val)
+        {
+            if (val < 1)
+                throw cmdlime::ValidationError("Value must be greater than 0");
+        };
         CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
         CMDLIME_FLAG(flg);
         CMDLIME_EXITFLAG(exitFlg);
@@ -1114,31 +1450,30 @@ TEST(GNUConfig, InvalidParamsWithExitFlag){
     EXPECT_EQ(cfg.exitFlg, true);
 }
 
-
-struct CustomType{
+struct CustomType {
     std::string value;
 };
 
-struct CustomTypeConfig: public Config{
+struct CustomTypeConfig : public Config {
     CMDLIME_PARAM(prm, CustomType);
     CMDLIME_PARAMLIST(prmList, std::vector<CustomType>) << cmdlime::ShortName{"l"};
     CMDLIME_ARG(argument, CustomType);
     CMDLIME_ARGLIST(argumentList, std::vector<CustomType>);
 };
 
-struct CustomTypeInt{
+struct CustomTypeInt {
     int value;
 };
 
-struct CustomTypeIntConfig: public Config{
+struct CustomTypeIntConfig : public Config {
     CMDLIME_PARAM(prm, CustomTypeInt);
     CMDLIME_PARAMLIST(prmList, std::vector<CustomTypeInt>) << cmdlime::ShortName{"l"};
     CMDLIME_ARG(argument, CustomTypeInt);
     CMDLIME_ARGLIST(argumentList, std::vector<CustomTypeInt>);
 };
 
-
-TEST(GNUConfig, CustomTypeUsage){
+TEST(GNUConfig, CustomTypeUsage)
+{
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     auto cfg = reader.read<CustomTypeConfig>(
             {"--prm", "hello world", "test arg", "--prm-list", "foo bar", "--prm-list", "baz", "1", "2 3"});
@@ -1152,10 +1487,11 @@ TEST(GNUConfig, CustomTypeUsage){
     EXPECT_EQ(cfg.argumentList.at(1).value, "2 3");
 }
 
-TEST(GNUConfig, CustomTypeIntUsage){
+TEST(GNUConfig, CustomTypeIntUsage)
+{
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<CustomTypeIntConfig>(
-            {"--prm", "10", "42", "--prm-list", "0", "--prm-list", "1", "43", "44"});
+    auto cfg =
+            reader.read<CustomTypeIntConfig>({"--prm", "10", "42", "--prm-list", "0", "--prm-list", "1", "43", "44"});
     EXPECT_EQ(cfg.prm.value, 10);
     ASSERT_EQ(cfg.prmList.size(), 2); //(std::vector<CustomType>{{"foo bar"}, {"baz"}}));
     EXPECT_EQ(cfg.prmList.at(0).value, 0);
@@ -1166,27 +1502,26 @@ TEST(GNUConfig, CustomTypeIntUsage){
     EXPECT_EQ(cfg.argumentList.at(1).value, 44);
 }
 
+} //namespace test_gnu_format
 
-}
+namespace cmdlime {
+template<>
+struct StringConverter<test_gnu_format::CustomType> {
+    static std::string toString(const test_gnu_format::CustomType& val)
+    {
+        return val.value;
+    }
 
-namespace cmdlime{
-    template<>
-    struct StringConverter<test_gnu_format::CustomType>{
-        static std::string toString(const test_gnu_format::CustomType& val)
-        {
-            return val.value;
-        }
-
-        static std::optional<test_gnu_format::CustomType> fromString(const std::string& str)
-        {
-            auto val = test_gnu_format::CustomType{};
-            val.value = str;
-            return val;
-        }
-    };
+    static std::optional<test_gnu_format::CustomType> fromString(const std::string& str)
+    {
+        auto val = test_gnu_format::CustomType{};
+        val.value = str;
+        return val;
+    }
+};
 
 template<>
-struct StringConverter<test_gnu_format::CustomTypeInt>{
+struct StringConverter<test_gnu_format::CustomTypeInt> {
     static std::string toString(const test_gnu_format::CustomTypeInt& val)
     {
         return std::to_string(val.value);
@@ -1199,4 +1534,4 @@ struct StringConverter<test_gnu_format::CustomTypeInt>{
         return val;
     }
 };
-}
+} //namespace cmdlime

--- a/tests/test_gnu_format.cpp
+++ b/tests/test_gnu_format.cpp
@@ -89,13 +89,13 @@ public:
 
 struct NonAggregateSubCommandCfg : public Config, public IConfig
 {
-    CMDLIME_INIT(NonAggregateSubCommandCfg);
+    using Config::Config;
     CMDLIME_PARAM(prm, std::string);
 };
 
 struct NonAggregateConfig : public Config, public IConfig
 {
-    CMDLIME_INIT(NonAggregateConfig);
+    using Config::Config;
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_COMMAND(cmd, NonAggregateSubCommandCfg);
 };

--- a/tests/test_nameutils.cpp
+++ b/tests/test_nameutils.cpp
@@ -1,5 +1,5 @@
-#include <gtest/gtest.h>
 #include <cmdlime/detail/nameutils.h>
+#include <gtest/gtest.h>
 
 using namespace cmdlime::detail;
 

--- a/tests/test_posix_format.cpp
+++ b/tests/test_posix_format.cpp
@@ -1,18 +1,18 @@
-#include <gtest/gtest.h>
-#include <cmdlime/config.h>
-#include <cmdlime/commandlinereader.h>
 #include "assert_exception.h"
+#include <cmdlime/commandlinereader.h>
+#include <cmdlime/config.h>
+#include <gtest/gtest.h>
 #include <optional>
 
-namespace test_posix_format{
+namespace test_posix_format {
 
 using namespace cmdlime;
 
-struct NestedSubcommandConfig: public Config{
+struct NestedSubcommandConfig : public Config {
     CMDLIME_PARAM(prm, std::string);
 };
 
-struct SubcommandConfig: public Config{
+struct SubcommandConfig : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::Name("i");
@@ -24,7 +24,7 @@ struct SubcommandConfig: public Config{
     CMDLIME_COMMAND(nested, NestedSubcommandConfig);
 };
 
-struct FullConfig : public Config{
+struct FullConfig : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::Name("i");
@@ -36,7 +36,7 @@ struct FullConfig : public Config{
     CMDLIME_SUBCOMMAND(subcommand, SubcommandConfig);
 };
 
-struct FullConfigWithCommand : public Config{
+struct FullConfigWithCommand : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::Name("i");
@@ -48,12 +48,26 @@ struct FullConfigWithCommand : public Config{
     CMDLIME_COMMAND(subcommand, SubcommandConfig);
 };
 
-
 TEST(PosixConfig, AllSet)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::POSIX>{};
-    auto cfg = reader.read<FullConfig>({"-r", "FOO", "-oBAR", "-i", "-9", "-L", "zero", "-L", "one",
-                                           "-O", "1,2", "-f", "4.2", "1.1", "2.2", "3.3"});
+    auto cfg = reader.read<FullConfig>(
+            {"-r",
+             "FOO",
+             "-oBAR",
+             "-i",
+             "-9",
+             "-L",
+             "zero",
+             "-L",
+             "one",
+             "-O",
+             "1,2",
+             "-f",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.optionalIntParam, -9);
@@ -68,10 +82,9 @@ TEST(PosixConfig, AllSet)
 TEST(PosixConfig, AllSetInSubCommand)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
-    auto cfg = reader.read<FullConfig>({"-r", "FOO", "-L", "zero", "-L", "one",
-                                           "4.2", "1.1",
-                                           "subcommand", "-r", "FOO", "-oBAR", "-i", "9", "-L", "zero", "-L", "one",
-                                           "-O", "1,2", "-f", "4.2", "1.1", "2.2", "3.3"});
+    auto cfg = reader.read<FullConfig>({"-r", "FOO", "-L",    "zero", "-L",  "one", "4.2",  "1.1", "subcommand",
+                                        "-r", "FOO", "-oBAR", "-i",   "9",   "-L",  "zero", "-L",  "one",
+                                        "-O", "1,2", "-f",    "4.2",  "1.1", "2.2", "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam);
@@ -93,7 +106,7 @@ TEST(PosixConfig, AllSetInSubCommand)
 
 TEST(PosixConfig, CombinedFlagsAndParams)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_FLAG(firstFlag);
         CMDLIME_FLAG(secondFlag);
         CMDLIME_FLAG(thirdFlag);
@@ -101,45 +114,48 @@ TEST(PosixConfig, CombinedFlagsAndParams)
     };
 
     {
-    auto reader = cmdlime::POSIXCommandLineReader{};
-    auto cfg = reader.read<Cfg>({"-fst", "-pfirst"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, true);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::POSIXCommandLineReader{};
+        auto cfg = reader.read<Cfg>({"-fst", "-pfirst"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, true);
+        EXPECT_EQ(cfg.prm, "first");
     }
 
     {
-    auto reader = cmdlime::POSIXCommandLineReader{};
-    auto cfg = reader.read<Cfg>({"-tfspfirst"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, true);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::POSIXCommandLineReader{};
+        auto cfg = reader.read<Cfg>({"-tfspfirst"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, true);
+        EXPECT_EQ(cfg.prm, "first");
     }
 
     {
-    auto reader = cmdlime::POSIXCommandLineReader{};
-    auto cfg = reader.read<Cfg>({"-fs", "-tp" "first"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, true);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::POSIXCommandLineReader{};
+        auto cfg = reader.read<Cfg>(
+                {"-fs",
+                 "-tp"
+                 "first"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, true);
+        EXPECT_EQ(cfg.prm, "first");
     }
 
     {
-    auto reader = cmdlime::POSIXCommandLineReader{};
-    auto cfg = reader.read<Cfg>({"-fs", "-p", "first"});
-    EXPECT_EQ(cfg.firstFlag, true);
-    EXPECT_EQ(cfg.secondFlag, true);
-    EXPECT_EQ(cfg.thirdFlag, false);
-    EXPECT_EQ(cfg.prm, "first");
+        auto reader = cmdlime::POSIXCommandLineReader{};
+        auto cfg = reader.read<Cfg>({"-fs", "-p", "first"});
+        EXPECT_EQ(cfg.firstFlag, true);
+        EXPECT_EQ(cfg.secondFlag, true);
+        EXPECT_EQ(cfg.thirdFlag, false);
+        EXPECT_EQ(cfg.prm, "first");
     }
 }
 
 TEST(PosixConfig, NumericParamsAndFlags)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_FLAG(flg) << cmdlime::Name("1");
         CMDLIME_PARAM(prm, std::string) << cmdlime::Name("2");
         CMDLIME_PARAM(paramSecond, std::string)("default");
@@ -179,37 +195,54 @@ TEST(PosixConfig, MissingOptionals)
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_EQ(cfg.optionalIntParam.has_value(), false);
     EXPECT_EQ(cfg.prmList, (std::vector<std::string>{"zero"}));
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 4.2);
     EXPECT_EQ(cfg.argumentList, (std::vector<float>{1.1f, 2.2f, 3.3f}));
 }
 
-
 TEST(PosixConfig, MissingParamAllSetInSubCommand)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"subcommand", "-r", "FOO", "-oBAR", "-i", "9", "-L", "zero", "-L", "one",
-                 "-O", "1,2", "-f", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-r' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"subcommand",
+                         "-r",
+                         "FOO",
+                         "-oBAR",
+                         "-i",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "-O",
+                         "1,2",
+                         "-f",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-r' is missing."});
+            });
 }
 
 TEST(PosixConfig, AllSetInCommand)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
-    auto cfg = reader.read<FullConfigWithCommand>({"-r", "FOO", "-L", "zero", "-L", "one", "4.2", "1.1",
-                                                      "subcommand", "-r", "FOO", "-oBAR", "-i", "9", "-L", "zero", "-L",
-                                                      "one",
-                                                      "-O", "1,2", "-f", "4.2", "1.1", "2.2", "3.3"});
+    auto cfg = reader.read<FullConfigWithCommand>(
+            {"-r", "FOO", "-L",   "zero", "-L",  "one", "4.2", "1.1", "subcommand", "-r",  "FOO", "-oBAR", "-i",
+             "9",  "-L",  "zero", "-L",   "one", "-O",  "1,2", "-f",  "4.2",        "1.1", "2.2", "3.3"});
     EXPECT_TRUE(cfg.requiredParam.empty());
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam);
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -228,13 +261,28 @@ TEST(PosixConfig, MissingParamAllSetInCommand)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     auto cfg = reader.read<FullConfigWithCommand>(
-            {"subcommand", "-r", "FOO", "-oBAR", "-i", "9", "-L", "zero", "-L", "one",
-             "-O", "1,2", "-f", "4.2", "1.1", "2.2", "3.3"});
+            {"subcommand",
+             "-r",
+             "FOO",
+             "-oBAR",
+             "-i",
+             "9",
+             "-L",
+             "zero",
+             "-L",
+             "one",
+             "-O",
+             "1,2",
+             "-f",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_TRUE(cfg.requiredParam.empty());
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam);
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -257,7 +305,7 @@ TEST(PosixConfig, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam);
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -266,7 +314,7 @@ TEST(PosixConfig, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.subcommand->optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.subcommand->optionalIntParam);
     EXPECT_TRUE(cfg.subcommand->prmList.empty());
-    EXPECT_EQ(cfg.subcommand->optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.subcommand->optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.subcommand->flg, false);
     EXPECT_EQ(cfg.subcommand->argument, 0.f);
     EXPECT_TRUE(cfg.subcommand->argumentList.empty());
@@ -274,8 +322,7 @@ TEST(PosixConfig, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.subcommand->nested->prm, "FOO");
 }
 
-
-struct FullConfigWithOptionalArgList : public Config{
+struct FullConfigWithOptionalArgList : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)({"defaultValue"});
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::Name("i");
@@ -300,192 +347,260 @@ TEST(PosixConfig, MissingParam)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-o", "FOO", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-r' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>({"-o", "FOO", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-r' is missing."});
+            });
 }
 
 TEST(PosixConfig, MissingArg)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfigWithOptionalArgList>({"-r", "FOO", "-o", "BAR", "-i", "9", "-f"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'argument' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfigWithOptionalArgList>({"-r", "FOO", "-o", "BAR", "-i", "9", "-f"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'argument' is missing."});
+            });
 }
 
 TEST(PosixConfig, MissingArgList)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'argument-list' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>({"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'argument-list' is missing."});
+            });
 }
 
 TEST(PosixConfig, MissingParamList)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "9", "-f", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-L' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-i", "9", "-f", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-L' is missing."});
+            });
 }
 
 TEST(PosixConfig, UnexpectedParam)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-r", "FOO", "-t", "TEST", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
-        });
+            [&]
+            {
+                auto cfg =
+                        reader.read<FullConfig>({"-r", "FOO", "-t", "TEST", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
+            });
 }
 
 TEST(PosixConfig, UnexpectedFlag)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>({"-r", "FOO", "-t", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>({"-r", "FOO", "-t", "-L", "zero", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-t'"});
+            });
 }
 
 TEST(PosixConfig, UnexpectedArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string);
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-p", "FOO", "4.2", "1"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '4.2'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-p", "FOO", "4.2", "1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '4.2'"});
+            });
 }
 
 TEST(PosixConfig, WrongCommandsOrder)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(optionalParam, int)(0);
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
     };
 
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ auto cfg = reader.read<Cfg>({"0", "1", "-o", "1", "2", "--"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Flags and parameters must precede arguments"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"0", "1", "-o", "1", "2", "--"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Flags and parameters must precede arguments"});
+            });
 }
 
 TEST(PosixConfig, WrongParamType)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "nine", "-L", "zero", "-f", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '-i' value from 'nine'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-i", "nine", "-L", "zero", "-f", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '-i' value from 'nine'"});
+            });
 }
 
 TEST(PosixConfig, WrongParamListElementType)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-L", "zero", "-O", "not-int", "-f", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '-O' value from 'not-int'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-L", "zero", "-O", "not-int", "-f", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '-O' value from 'not-int'"});
+            });
 }
 
 TEST(PosixConfig, WrongArgType)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "fortytwo", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "fortytwo", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
+            });
 }
 
 TEST(PosixConfig, WrongArgListElementType)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2", "1.1", "2.2", "three"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set argument list 'argument-list' element's value from 'three'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-r", "FOO", "-o", "BAR", "-i", "9", "-L", "zero", "-f", "4.2", "1.1", "2.2", "three"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument list 'argument-list' element's value from 'three'"});
+            });
 }
 
 TEST(PosixConfig, ParamEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string);
         CMDLIME_FLAG(flg);
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-p"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-p"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
+            });
 }
 
 TEST(PosixConfig, ParamListEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAMLIST(params, std::vector<std::string>);
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-p"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-p"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-p' value can't be empty"});
+            });
 }
 
 TEST(PosixConfig, ArgEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARG(argument, std::string);
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({""});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' value can't be empty"});
+            });
 }
 
 TEST(PosixConfig, ArgListEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARGLIST(args, std::vector<std::string>);
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"foo", ""});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'args' element value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"foo", ""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'args' element value can't be empty"});
+            });
 }
-
 
 TEST(PosixConfig, ValuesWithWhitespace)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string);
         CMDLIME_PARAMLIST(prmList, std::vector<std::string>) << cmdlime::Name("L");
         CMDLIME_ARG(argument, std::string);
@@ -501,33 +616,45 @@ TEST(PosixConfig, ValuesWithWhitespace)
 
 TEST(PosixConfig, ParamWrongNameTooLong)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::Name("prm");
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-pname"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'prm' can't have more than one symbol"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-pname"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name 'prm' can't have more than one symbol"});
+            });
 }
 
 TEST(PosixConfig, ParamWrongNameNonAlphanum)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::Name("$");
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-pname"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name '$' must be an alphanumeric character"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-pname"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name '$' must be an alphanumeric character"});
+            });
 }
 
 TEST(PosixConfig, NegativeNumberToArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARG(argument, int);
         CMDLIME_ARG(argumentStr, std::string);
         CMDLIME_ARGLIST(argumentList, std::vector<double>);
@@ -541,20 +668,24 @@ TEST(PosixConfig, NegativeNumberToArg)
 
 TEST(PosixConfig, NegativeNumberWithoutArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, int);
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<Cfg>({"-2"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '-2'"});
-        });
+            [&]
+            {
+                reader.read<Cfg>({"-2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '-2'"});
+            });
 }
 
 TEST(PosixConfig, ArgsDelimiter)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, int);
         CMDLIME_PARAM(optionalParam, int)(0);
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
@@ -569,7 +700,7 @@ TEST(PosixConfig, ArgsDelimiter)
 
 TEST(PosixConfig, ArgsDelimiterFront)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(optionalParam, int)(0);
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
     };
@@ -582,7 +713,7 @@ TEST(PosixConfig, ArgsDelimiterFront)
 
 TEST(PosixConfig, ArgsDelimiterBack)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(optionalParam, int)(0);
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
     };
@@ -595,7 +726,7 @@ TEST(PosixConfig, ArgsDelimiterBack)
 
 TEST(PosixConfig, PascalNames)
 {
-    struct PascalConfig : public Config{
+    struct PascalConfig : public Config {
         CMDLIME_PARAM(RequiredParam, std::string);
         CMDLIME_PARAM(OptionalParam, std::string)("defaultValue");
         CMDLIME_PARAM(IntParamOptional, std::optional<int>)();
@@ -605,9 +736,27 @@ TEST(PosixConfig, PascalNames)
         CMDLIME_ARG(argument, double);
         CMDLIME_ARGLIST(argumentList, std::vector<float>);
     };
-   auto reader = cmdlime::POSIXCommandLineReader{};
-    auto cfg = reader.read<PascalConfig>({"-r", "FOO", "-o", "BAR", "-i", "9", "-l", "zero", "-l", "one",
-                                             "-m", "1", "-m", "2", "-f", "4.2", "1.1", "2.2", "3.3"});
+    auto reader = cmdlime::POSIXCommandLineReader{};
+    auto cfg = reader.read<PascalConfig>(
+            {"-r",
+             "FOO",
+             "-o",
+             "BAR",
+             "-i",
+             "9",
+             "-l",
+             "zero",
+             "-l",
+             "one",
+             "-m",
+             "1",
+             "-m",
+             "2",
+             "-f",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.RequiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.OptionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.IntParamOptional, 9);
@@ -620,81 +769,99 @@ TEST(PosixConfig, PascalNames)
 
 TEST(PosixConfig, CustomNamesMissingParam)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, double) << cmdlime::Name{"P"};
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-P' is missing."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-P' is missing."});
+            });
 }
 
 TEST(PosixConfig, CustomNamesMissingParamList)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, double) << cmdlime::Name{"P"};
         CMDLIME_PARAMLIST(prmList, std::vector<float>) << cmdlime::Name{"L"};
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({"-P1"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-L' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({"-P1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-L' is missing."});
+            });
 }
 
 TEST(PosixConfig, CustomNamesMissingArg)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_ARG(argument, double) << cmdlime::Name{"a"};
         CMDLIME_ARGLIST(argumentList, std::vector<float>) << cmdlime::Name{"A"};
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'a' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'a' is missing."});
+            });
 }
 
 TEST(PosixConfig, CustomNamesMissingArgList)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_ARG(argument, double) << cmdlime::Name{"a"};
         CMDLIME_ARGLIST(argumentList, std::vector<float>) << cmdlime::Name{"A"};
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<TestConfig>({"1.0"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'A' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({"1.0"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'A' is missing."});
+            });
 }
 
 TEST(PosixConfig, ConfigErrorRepeatingParamNames)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(Prm, double)();
         CMDLIME_PARAM(prm, int)();
     };
     auto reader = cmdlime::POSIXCommandLineReader{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'p' is already used."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'p' is already used."});
+            });
 }
 
 TEST(PosixConfig, UsageInfo)
 {
     auto reader = cmdlime::POSIXCommandLineReader{};
     reader.setProgramName("testproc");
-    auto expectedInfo = std::string{
-    "Usage: testproc [commands] <argument> -r <string> -L <string>... "
-    "[-o <string>] [-i <int>] [-O <int>...] [-f] <argument-list...>\n"
-    };
+    auto expectedInfo = std::string{"Usage: testproc [commands] <argument> -r <string> -L <string>... "
+                                    "[-o <string>] [-i <int>] [-O <int>...] [-f] <argument-list...>\n"};
     EXPECT_EQ(reader.usageInfo<FullConfig>(), expectedInfo);
 }
 
@@ -703,25 +870,26 @@ TEST(PosixConfig, DetailedUsageInfo)
     auto reader = cmdlime::POSIXCommandLineReader{};
     reader.setProgramName("testproc");
     auto expectedDetailedInfo = std::string{
-    "Usage: testproc [commands] <argument> -r <string> -L <string>... [params] [flags] <argument-list...>\n"
-    "Arguments:\n"
-    "    <argument> (double)         \n"
-    "    <argument-list> (float)     multi-value\n"
-    "Parameters:\n"
-    "   -r <string>                  \n"
-    "   -L <string>                  multi-value\n"
-    "   -o <string>                  optional, default: defaultValue\n"
-    "   -i <int>                     optional\n"
-    "   -O <int>                     multi-value, optional, default: {99, 100}\n"
-    "Flags:\n"
-    "   -f                           \n"
-    "Commands:\n"
-    "    subcommand [options]        \n"};
+            "Usage: testproc [commands] <argument> -r <string> -L <string>... [params] [flags] <argument-list...>\n"
+            "Arguments:\n"
+            "    <argument> (double)         \n"
+            "    <argument-list> (float)     multi-value\n"
+            "Parameters:\n"
+            "   -r <string>                  \n"
+            "   -L <string>                  multi-value\n"
+            "   -o <string>                  optional, default: defaultValue\n"
+            "   -i <int>                     optional\n"
+            "   -O <int>                     multi-value, optional, default: {99, 100}\n"
+            "Flags:\n"
+            "   -f                           \n"
+            "Commands:\n"
+            "    subcommand [options]        \n"};
     EXPECT_EQ(reader.usageInfoDetailed<FullConfig>(), expectedDetailedInfo);
 }
 
-TEST(PosixConfig, WrongParamsWithExitFlag){
-    struct ConfigWithExitFlag : public Config{
+TEST(PosixConfig, WrongParamsWithExitFlag)
+{
+    struct ConfigWithExitFlag : public Config {
         CMDLIME_PARAM(requiredParam, int);
         CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
         CMDLIME_FLAG(flg);
@@ -734,4 +902,4 @@ TEST(PosixConfig, WrongParamsWithExitFlag){
     EXPECT_EQ(cfg.exitFlg, true);
 }
 
-}
+} //namespace test_posix_format

--- a/tests/test_simple_format.cpp
+++ b/tests/test_simple_format.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-#include <cmdlime/config.h>
-#include <cmdlime/commandlinereader.h>
 #include "assert_exception.h"
+#include <cmdlime/commandlinereader.h>
+#include <cmdlime/config.h>
+#include <gtest/gtest.h>
 #include <optional>
 
 namespace test_simple_format {
@@ -48,13 +48,21 @@ struct FullConfigWithCommand : public Config {
     CMDLIME_COMMAND(subcommand, SubcommandConfig);
 };
 
-
 TEST(SimpleConfig, AllSet)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     auto cfg = reader.read<FullConfig>(
-            {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=-9", "-prmList=zero", "-prmList=one",
-             "-optionalParamList=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredParam=FOO",
+             "-optionalParam=BAR",
+             "-optionalIntParam=-9",
+             "-prmList=zero",
+             "-prmList=one",
+             "-optionalParamList=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.optionalIntParam, -9);
@@ -69,10 +77,24 @@ TEST(SimpleConfig, AllSet)
 TEST(SimpleConfig, AllSetInSubCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
-    auto cfg = reader.read<FullConfig>({"-requiredParam=FOO", "-prmList=zero", "-prmList=one", "4.2", "1.1",
-                                           "subcommand", "-requiredParam=FOO", "-optionalParam=BAR",
-                                           "-optionalIntParam=9", "-prmList=zero", "-prmList=one",
-                                           "-optionalParamList=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+    auto cfg = reader.read<FullConfig>(
+            {"-requiredParam=FOO",
+             "-prmList=zero",
+             "-prmList=one",
+             "4.2",
+             "1.1",
+             "subcommand",
+             "-requiredParam=FOO",
+             "-optionalParam=BAR",
+             "-optionalIntParam=9",
+             "-prmList=zero",
+             "-prmList=one",
+             "-optionalParamList=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
@@ -110,14 +132,24 @@ TEST(SimpleConfig, MissingParamAllSetInSubCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"subcommand", "-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9",
+                        {"subcommand",
+                         "-requiredParam=FOO",
+                         "-optionalParam=BAR",
+                         "-optionalIntParam=9",
                          "-prmList=zero",
                          "-prmList=one",
-                         "-optionalParamList=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+                         "-optionalParamList=1,2",
+                         "--flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
             },
-            [](const cmdlime::ParsingError& error) {
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-requiredParam' is missing."});
             });
 }
@@ -126,10 +158,23 @@ TEST(SimpleConfig, AllSetInCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     auto cfg = reader.read<FullConfigWithCommand>(
-            {"-requiredParam=FOO", "-prmList=zero", "-prmList=one", "4.2", "1.1",
-             "subcommand", "-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero",
+            {"-requiredParam=FOO",
+             "-prmList=zero",
              "-prmList=one",
-             "-optionalParamList=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+             "4.2",
+             "1.1",
+             "subcommand",
+             "-requiredParam=FOO",
+             "-optionalParam=BAR",
+             "-optionalIntParam=9",
+             "-prmList=zero",
+             "-prmList=one",
+             "-optionalParamList=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_TRUE(cfg.requiredParam.empty());
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
@@ -153,9 +198,18 @@ TEST(SimpleConfig, MissingParamAllSetInCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     auto cfg = reader.read<FullConfigWithCommand>(
-            {"subcommand", "-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero",
+            {"subcommand",
+             "-requiredParam=FOO",
+             "-optionalParam=BAR",
+             "-optionalIntParam=9",
+             "-prmList=zero",
              "-prmList=one",
-             "-optionalParamList=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+             "-optionalParamList=1,2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_TRUE(cfg.requiredParam.empty());
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
@@ -200,7 +254,6 @@ TEST(SimpleConfig, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.subcommand->nested->prm, "FOO");
 }
 
-
 struct FullConfigWithOptionalArgList : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)({"defaultValue"});
@@ -226,8 +279,12 @@ TEST(SimpleConfig, MissingParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { reader.read<FullConfig>({"-optionalParam=FOO", "-prmList=zero", "4.2", "1.1", "2.2", "3.3"}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                reader.read<FullConfig>({"-optionalParam=FOO", "-prmList=zero", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-requiredParam' is missing."});
             });
 }
@@ -236,11 +293,13 @@ TEST(SimpleConfig, MissingArg)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfigWithOptionalArgList>(
                         {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "--flg"});
             },
-            [](const cmdlime::ParsingError& error) {
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'argument' is missing."});
             });
 }
@@ -249,12 +308,18 @@ TEST(SimpleConfig, MissingArgList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero", "--flg",
+                        {"-requiredParam=FOO",
+                         "-optionalParam=BAR",
+                         "-optionalIntParam=9",
+                         "-prmList=zero",
+                         "--flg",
                          "4.2"});
             },
-            [](const cmdlime::ParsingError& error) {
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'argumentList' is missing."});
             });
 }
@@ -263,13 +328,20 @@ TEST(SimpleConfig, MissingParamList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "--flg", "4.2", "1.1",
+                        {"-requiredParam=FOO",
+                         "-optionalParam=BAR",
+                         "-optionalIntParam=9",
+                         "--flg",
+                         "4.2",
+                         "1.1",
                          "2.2",
                          "3.3"});
             },
-            [](const cmdlime::ParsingError& error) {
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-prmList' is missing."});
             });
 }
@@ -278,11 +350,13 @@ TEST(SimpleConfig, UnexpectedParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
                         {"-requiredParam=FOO", "-testParam=TEST", "-prmList=zero", "4.2", "1.1", "2.2", "3.3"});
             },
-            [](const cmdlime::ParsingError& error) {
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter '-testParam'"});
             });
 }
@@ -291,11 +365,13 @@ TEST(SimpleConfig, UnexpectedFlag)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
                         {"-requiredParam=FOO", "--testFlag", "-prmList=zero", "4.2", "1.1", "2.2", "3.3"});
             },
-            [](const cmdlime::ParsingError& error) {
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown flag '--testFlag'"});
             });
 }
@@ -307,25 +383,38 @@ TEST(SimpleConfig, UnexpectedArg)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { reader.read<Cfg>({"-prm=FOO", "4.2", "1"}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                reader.read<Cfg>({"-prm=FOO", "4.2", "1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '4.2'"});
             });
-
 }
 
 TEST(SimpleConfig, WrongParamType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=nine", "-prmList=zero", "--flg",
-                         "4.2", "1.1", "2.2", "3.3"});
+                        {"-requiredParam=FOO",
+                         "-optionalParam=BAR",
+                         "-optionalIntParam=nine",
+                         "-prmList=zero",
+                         "--flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
             },
-            [](const cmdlime::ParsingError& error) {
-                EXPECT_EQ(std::string{error.what()},
-                          std::string{"Couldn't set parameter '-optionalIntParam' value from 'nine'"});
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set parameter '-optionalIntParam' value from 'nine'"});
             });
 }
 
@@ -333,15 +422,24 @@ TEST(SimpleConfig, WrongParamListElementType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-requiredParam=FOO", "-optionalParam=BAR", "-prmList=zero", "-optionalParamList=not-int",
+                        {"-requiredParam=FOO",
+                         "-optionalParam=BAR",
+                         "-prmList=zero",
+                         "-optionalParamList=not-int",
                          "--flg",
-                         "4.2", "1.1", "2.2", "3.3"});
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
             },
-            [](const cmdlime::ParsingError& error) {
-                EXPECT_EQ(std::string{error.what()},
-                          std::string{"Couldn't set parameter '-optionalParamList' value from 'not-int'"});
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set parameter '-optionalParamList' value from 'not-int'"});
             });
 }
 
@@ -349,14 +447,24 @@ TEST(SimpleConfig, WrongArgType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero", "--flg",
-                         "fortytwo", "1.1", "2.2", "3.3"});
+                        {"-requiredParam=FOO",
+                         "-optionalParam=BAR",
+                         "-optionalIntParam=9",
+                         "-prmList=zero",
+                         "--flg",
+                         "fortytwo",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
             },
-            [](const cmdlime::ParsingError& error) {
-                EXPECT_EQ(std::string{error.what()},
-                          std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
             });
 }
 
@@ -364,15 +472,24 @@ TEST(SimpleConfig, WrongArgListElementType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] {
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero", "--flg",
+                        {"-requiredParam=FOO",
+                         "-optionalParam=BAR",
+                         "-optionalIntParam=9",
+                         "-prmList=zero",
+                         "--flg",
                          "4.2",
-                         "1.1", "2.2", "three"});
+                         "1.1",
+                         "2.2",
+                         "three"});
             },
-            [](const cmdlime::ParsingError& error) {
-                EXPECT_EQ(std::string{error.what()},
-                          std::string{"Couldn't set argument list 'argumentList' element's value from 'three'"});
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument list 'argumentList' element's value from 'three'"});
             });
 }
 
@@ -383,10 +500,15 @@ TEST(SimpleConfig, ParamWrongNameNonAlphaFirstChar)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ConfigError>(
-            [&] { reader.read<Cfg>({"-!param=Foo"}); },
-            [](const cmdlime::ConfigError& error) {
-                EXPECT_EQ(std::string{error.what()},
-                          std::string{"Parameter's name '!param' must start with an alphabet character"});
+            [&]
+            {
+                reader.read<Cfg>({"-!param=Foo"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name '!param' must start with an alphabet character"});
             });
 }
 
@@ -397,10 +519,15 @@ TEST(SimpleConfig, ParamWrongNameNonAlphanum)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ConfigError>(
-            [&] { reader.read<Cfg>({"-pa-ram=Foo"}); },
-            [](const cmdlime::ConfigError& error) {
-                EXPECT_EQ(std::string{error.what()},
-                          std::string{"Parameter's name 'p$r$m' must consist of alphanumeric characters"});
+            [&]
+            {
+                reader.read<Cfg>({"-pa-ram=Foo"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name 'p$r$m' must consist of alphanumeric characters"});
             });
 }
 
@@ -413,8 +540,12 @@ TEST(SimpleConfig, MultipleArgLists)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ConfigError>(
-            [&] { reader.read<Cfg>({"-param=Foo"}); },
-            [](const cmdlime::ConfigError& error) {
+            [&]
+            {
+                reader.read<Cfg>({"-param=Foo"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"BaseConfig can have only one arguments list"});
             });
 }
@@ -426,8 +557,12 @@ TEST(SimpleConfig, ParamEmptyValue)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { reader.read<Cfg>({"-param="}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                reader.read<Cfg>({"-param="});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-param' value can't be empty"});
             });
 }
@@ -439,8 +574,12 @@ TEST(SimpleConfig, ParamListEmptyValue)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { reader.read<Cfg>({"-params=", ""}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                reader.read<Cfg>({"-params=", ""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-params' value can't be empty"});
             });
 }
@@ -452,8 +591,12 @@ TEST(SimpleConfig, ArgEmptyValue)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { reader.read<Cfg>({""}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                reader.read<Cfg>({""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' value can't be empty"});
             });
 }
@@ -465,12 +608,15 @@ TEST(SimpleConfig, ArgListEmptyValue)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { reader.read<Cfg>({"foo", ""}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                reader.read<Cfg>({"foo", ""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'args' element value can't be empty"});
             });
 }
-
 
 TEST(SimpleConfig, ValuesWithWhitespace)
 {
@@ -495,10 +641,15 @@ TEST(SimpleConfig, ParamWrongFormat)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { auto cfg = reader.read<Cfg>({"-param:2"}); },
-            [](const cmdlime::ParsingError& error) {
-                EXPECT_EQ(std::string{error.what()},
-                          std::string{"Wrong parameter format: -param:2. Parameter must have a form of -name=value"});
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-param:2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Wrong parameter format: -param:2. Parameter must have a form of -name=value"});
             });
 }
 
@@ -523,8 +674,12 @@ TEST(SimpleConfig, NegativeNumberWithoutArg)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { reader.read<Cfg>({"-2"}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                reader.read<Cfg>({"-2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '-2'"});
             });
 }
@@ -584,8 +739,18 @@ TEST(SimpleConfig, PascalNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     auto cfg = reader.read<PascalConfig>(
-            {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero", "-prmList=one",
-             "-optionalParamList=1", "-optionalParamList=2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredParam=FOO",
+             "-optionalParam=BAR",
+             "-optionalIntParam=9",
+             "-prmList=zero",
+             "-prmList=one",
+             "-optionalParamList=1",
+             "-optionalParamList=2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.RequiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.OptionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.OptionalIntParam, 9);
@@ -610,8 +775,18 @@ TEST(SimpleConfig, SnakeNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     auto cfg = reader.read<PascalConfig>(
-            {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-paramList=zero", "-paramList=one",
-             "-optionalParamList=1", "-optionalParamList=2", "--flg", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredParam=FOO",
+             "-optionalParam=BAR",
+             "-optionalIntParam=9",
+             "-paramList=zero",
+             "-paramList=one",
+             "-optionalParamList=1",
+             "-optionalParamList=2",
+             "--flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.required_param, std::string{"FOO"});
     EXPECT_EQ(cfg.optional_param, std::string{"BAR"});
     EXPECT_EQ(cfg.optional_int_param, 9);
@@ -634,8 +809,14 @@ TEST(SimpleConfig, CustomNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     auto cfg = reader.read<TestConfig>(
-            {"-customRequiredParam=FOO", "-customOptionalParam=BAR", "-customOptionalIntParam=9", "--customFlag", "4.2",
-             "1.1", "2.2", "3.3"});
+            {"-customRequiredParam=FOO",
+             "-customOptionalParam=BAR",
+             "-customOptionalIntParam=9",
+             "--customFlag",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.optionalIntParam, 9);
@@ -652,8 +833,12 @@ TEST(SimpleConfig, CustomNamesMissingParam)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { auto cfg = reader.read<TestConfig>({}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-customParam' is missing."});
             });
 }
@@ -666,8 +851,12 @@ TEST(SimpleConfig, CustomNamesMissingParamList)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { auto cfg = reader.read<TestConfig>({"-customParam=1"}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({"-customParam=1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-customParamList' is missing."});
             });
 }
@@ -680,8 +869,12 @@ TEST(SimpleConfig, CustomNamesMissingArg)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { auto cfg = reader.read<TestConfig>({}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'customArg' is missing."});
             });
 }
@@ -694,8 +887,12 @@ TEST(SimpleConfig, CustomNamesMissingArgList)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ParsingError>(
-            [&] { auto cfg = reader.read<TestConfig>({"1.0"}); },
-            [](const cmdlime::ParsingError& error) {
+            [&]
+            {
+                auto cfg = reader.read<TestConfig>({"1.0"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'customArgList' is missing."});
             });
 }
@@ -708,8 +905,12 @@ TEST(SimpleConfig, ConfigErrorRepeatingParamNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ConfigError>(
-            [&] { reader.read<TestConfig>({}); },
-            [](const cmdlime::ConfigError& error) {
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'prm' is already used."});
             });
 }
@@ -722,8 +923,12 @@ TEST(SimpleConfig, ConfigErrorRepeatingFlagNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     assert_exception<cmdlime::ConfigError>(
-            [&] { reader.read<TestConfig>({}); },
-            [](const cmdlime::ConfigError& error) {
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
                 EXPECT_EQ(std::string{error.what()}, std::string{"Flag's name 'flg' is already used."});
             });
 }
@@ -732,10 +937,10 @@ TEST(SimpleConfig, UsageInfo)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     reader.setProgramName("testproc");
-    auto expectedInfo = std::string{
-            "Usage: testproc [commands] <argument> -requiredParam=<string> -prmList=<string>... "
-            "[-optionalParam=<string>] [-optionalIntParam=<int>] [-optionalParamList=<int>...] [--flg] <argumentList...>\n"
-    };
+    auto expectedInfo =
+            std::string{"Usage: testproc [commands] <argument> -requiredParam=<string> -prmList=<string>... "
+                        "[-optionalParam=<string>] [-optionalIntParam=<int>] [-optionalParamList=<int>...] [--flg] "
+                        "<argumentList...>\n"};
     EXPECT_EQ(reader.usageInfo<FullConfig>(), expectedInfo);
 }
 
@@ -743,22 +948,21 @@ TEST(SimpleConfig, DetailedUsageInfo)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     reader.setProgramName("testproc");
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc [commands] <argument> -requiredParam=<string> -prmList=<string>... [params] [flags] <argumentList...>\n"
-            "Arguments:\n"
-            "    <argument> (double)        \n"
-            "    <argumentList> (float)     multi-value\n"
-            "Parameters:\n"
-            "   -requiredParam=<string>     \n"
-            "   -prmList=<string>           multi-value\n"
-            "   -optionalParam=<string>     optional, default: defaultValue\n"
-            "   -optionalIntParam=<int>     optional\n"
-            "   -optionalParamList=<int>    multi-value, optional, default: {99, 100}\n"
-            "Flags:\n"
-            "  --flg                        \n"
-            "Commands:\n"
-            "    subcommand [options]       \n"
-    };
+    auto expectedDetailedInfo = std::string{"Usage: testproc [commands] <argument> -requiredParam=<string> "
+                                            "-prmList=<string>... [params] [flags] <argumentList...>\n"
+                                            "Arguments:\n"
+                                            "    <argument> (double)        \n"
+                                            "    <argumentList> (float)     multi-value\n"
+                                            "Parameters:\n"
+                                            "   -requiredParam=<string>     \n"
+                                            "   -prmList=<string>           multi-value\n"
+                                            "   -optionalParam=<string>     optional, default: defaultValue\n"
+                                            "   -optionalIntParam=<int>     optional\n"
+                                            "   -optionalParamList=<int>    multi-value, optional, default: {99, 100}\n"
+                                            "Flags:\n"
+                                            "  --flg                        \n"
+                                            "Commands:\n"
+                                            "    subcommand [options]       \n"};
     EXPECT_EQ(reader.usageInfoDetailed<FullConfig>(), expectedDetailedInfo);
 }
 
@@ -771,27 +975,25 @@ TEST(SimpleConfig, DetailedUsageInfoFormat)
     format.nameIndentation = 0;
     format.terminalWidth = 50;
     reader.setUsageInfoFormat(format);
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc [commands] <argument> -requiredParam=<string> -prmList=<string>... [params] [flags] <argumentList...>\n"
-            "Arguments:\n"
-            "<argument> (double)       \n"
-            "<argumentList> (float)    multi-value\n"
-            "Parameters:\n"
-            "-requiredParam=<string>   \n"
-            "-prmList=<string>         multi-value\n"
-            "-optionalParam=<string>   optional, default: \n"
-            "                            defaultValue\n"
-            "-optionalIntParam=<int>   optional\n"
-            "-optionalParamList=<int>  multi-value, optional,\n"
-            "                            default: {99, 100}\n"
-            "Flags:\n"
-            "--flg                     \n"
-            "Commands:\n"
-            "subcommand [options]      \n"
-    };
+    auto expectedDetailedInfo = std::string{"Usage: testproc [commands] <argument> -requiredParam=<string> "
+                                            "-prmList=<string>... [params] [flags] <argumentList...>\n"
+                                            "Arguments:\n"
+                                            "<argument> (double)       \n"
+                                            "<argumentList> (float)    multi-value\n"
+                                            "Parameters:\n"
+                                            "-requiredParam=<string>   \n"
+                                            "-prmList=<string>         multi-value\n"
+                                            "-optionalParam=<string>   optional, default: \n"
+                                            "                            defaultValue\n"
+                                            "-optionalIntParam=<int>   optional\n"
+                                            "-optionalParamList=<int>  multi-value, optional,\n"
+                                            "                            default: {99, 100}\n"
+                                            "Flags:\n"
+                                            "--flg                     \n"
+                                            "Commands:\n"
+                                            "subcommand [options]      \n"};
     EXPECT_EQ(reader.usageInfoDetailed<FullConfig>(), expectedDetailedInfo);
 }
-
 
 TEST(SimpleConfig, CustomValueNames)
 {
@@ -804,18 +1006,15 @@ TEST(SimpleConfig, CustomValueNames)
 
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{};
     reader.setProgramName("testproc");
-    auto expectedInfo = std::string{
-            "Usage: testproc <argument> -prm=<STRING> [params] <argumentList...>\n"
-            "Arguments:\n"
-            "    <argument> (DOUBLE)         \n"
-            "    <argumentList> (FLOATS)     multi-value\n"
-            "Parameters:\n"
-            "   -prm=<STRING>                \n"
-            "   -prmList=<INTS>              multi-value, optional, default: {}\n"
-    };
+    auto expectedInfo = std::string{"Usage: testproc <argument> -prm=<STRING> [params] <argumentList...>\n"
+                                    "Arguments:\n"
+                                    "    <argument> (DOUBLE)         \n"
+                                    "    <argumentList> (FLOATS)     multi-value\n"
+                                    "Parameters:\n"
+                                    "   -prm=<STRING>                \n"
+                                    "   -prmList=<INTS>              multi-value, optional, default: {}\n"};
     EXPECT_EQ(reader.usageInfoDetailed<TestConfig>(), expectedInfo);
 }
-
 
 TEST(SimpleConfig, WrongParamsWithExitFlag)
 {
@@ -838,7 +1037,14 @@ TEST(SimpleConfig, ExecMissingVersionInfo)
     auto errorOutput = std::stringstream{};
     reader.setErrorOutputStream(errorOutput);
 
-    EXPECT_EQ(reader.exec<FullConfig>({"--version"}, [](const FullConfig&) { return 0; }), -1);
+    EXPECT_EQ(
+            reader.exec<FullConfig>(
+                    {"--version"},
+                    [](const FullConfig&)
+                    {
+                        return 0;
+                    }),
+            -1);
     EXPECT_EQ(errorOutput.str(), "Encountered unknown flag '--version'\n");
 }
 
@@ -848,7 +1054,14 @@ TEST(SimpleConfig, ExecVersion)
     reader.setVersionInfo("testproc 1.0");
     auto output = std::stringstream{};
     reader.setOutputStream(output);
-    EXPECT_EQ(reader.exec<FullConfig>({"--version"}, [](const FullConfig&) { return 0; }), 0);
+    EXPECT_EQ(
+            reader.exec<FullConfig>(
+                    {"--version"},
+                    [](const FullConfig&)
+                    {
+                        return 0;
+                    }),
+            0);
     EXPECT_EQ(output.str(), "testproc 1.0\n");
 }
 
@@ -857,24 +1070,30 @@ TEST(SimpleConfig, ExecHelp)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc"};
     auto output = std::stringstream{};
     reader.setOutputStream(output);
-    EXPECT_EQ(reader.exec<FullConfig>({"--help"}, [](const FullConfig&) { return 0; }), 0);
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc [commands] <argument> -requiredParam=<string> -prmList=<string>... [params] [flags] <argumentList...>\n"
-            "Arguments:\n"
-            "    <argument> (double)        \n"
-            "    <argumentList> (float)     multi-value\n"
-            "Parameters:\n"
-            "   -requiredParam=<string>     \n"
-            "   -prmList=<string>           multi-value\n"
-            "   -optionalParam=<string>     optional, default: defaultValue\n"
-            "   -optionalIntParam=<int>     optional\n"
-            "   -optionalParamList=<int>    multi-value, optional, default: {99, 100}\n"
-            "Flags:\n"
-            "  --flg                        \n"
-            "  --help                       show usage info and exit\n"
-            "Commands:\n"
-            "    subcommand [options]       \n\n"
-    };
+    EXPECT_EQ(
+            reader.exec<FullConfig>(
+                    {"--help"},
+                    [](const FullConfig&)
+                    {
+                        return 0;
+                    }),
+            0);
+    auto expectedDetailedInfo = std::string{"Usage: testproc [commands] <argument> -requiredParam=<string> "
+                                            "-prmList=<string>... [params] [flags] <argumentList...>\n"
+                                            "Arguments:\n"
+                                            "    <argument> (double)        \n"
+                                            "    <argumentList> (float)     multi-value\n"
+                                            "Parameters:\n"
+                                            "   -requiredParam=<string>     \n"
+                                            "   -prmList=<string>           multi-value\n"
+                                            "   -optionalParam=<string>     optional, default: defaultValue\n"
+                                            "   -optionalIntParam=<int>     optional\n"
+                                            "   -optionalParamList=<int>    multi-value, optional, default: {99, 100}\n"
+                                            "Flags:\n"
+                                            "  --flg                        \n"
+                                            "  --help                       show usage info and exit\n"
+                                            "Commands:\n"
+                                            "    subcommand [options]       \n\n"};
     EXPECT_EQ(output.str(), expectedDetailedInfo);
 }
 
@@ -888,27 +1107,33 @@ TEST(SimpleConfig, ExecHelpUsageInfoFormat)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc", {}, format};
     auto output = std::stringstream{};
     reader.setOutputStream(output);
-    EXPECT_EQ(reader.exec<FullConfig>({"--help"}, [](const FullConfig&) { return 0; }), 0);
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc [commands] <argument> -requiredParam=<string> -prmList=<string>... [params] [flags] <argumentList...>\n"
-            "Arguments:\n"
-            "<argument> (double)       \n"
-            "<argumentList> (float)    multi-value\n"
-            "Parameters:\n"
-            "-requiredParam=<string>   \n"
-            "-prmList=<string>         multi-value\n"
-            "-optionalParam=<string>   optional, default: \n"
-            "                            defaultValue\n"
-            "-optionalIntParam=<int>   optional\n"
-            "-optionalParamList=<int>  multi-value, optional,\n"
-            "                            default: {99, 100}\n"
-            "Flags:\n"
-            "--flg                     \n"
-            "--help                    show usage info and \n"
-            "                            exit\n"
-            "Commands:\n"
-            "subcommand [options]      \n\n"
-    };
+    EXPECT_EQ(
+            reader.exec<FullConfig>(
+                    {"--help"},
+                    [](const FullConfig&)
+                    {
+                        return 0;
+                    }),
+            0);
+    auto expectedDetailedInfo = std::string{"Usage: testproc [commands] <argument> -requiredParam=<string> "
+                                            "-prmList=<string>... [params] [flags] <argumentList...>\n"
+                                            "Arguments:\n"
+                                            "<argument> (double)       \n"
+                                            "<argumentList> (float)    multi-value\n"
+                                            "Parameters:\n"
+                                            "-requiredParam=<string>   \n"
+                                            "-prmList=<string>         multi-value\n"
+                                            "-optionalParam=<string>   optional, default: \n"
+                                            "                            defaultValue\n"
+                                            "-optionalIntParam=<int>   optional\n"
+                                            "-optionalParamList=<int>  multi-value, optional,\n"
+                                            "                            default: {99, 100}\n"
+                                            "Flags:\n"
+                                            "--flg                     \n"
+                                            "--help                    show usage info and \n"
+                                            "                            exit\n"
+                                            "Commands:\n"
+                                            "subcommand [options]      \n\n"};
     EXPECT_EQ(output.str(), expectedDetailedInfo);
 }
 
@@ -917,24 +1142,30 @@ TEST(SimpleConfig, ExecCommandHelp)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc"};
     auto output = std::stringstream{};
     reader.setOutputStream(output);
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc subcommand [commands] <argument> -requiredParam=<string> -prmList=<string>... [params] [flags] <argumentList...>\n"
-            "Arguments:\n"
-            "    <argument> (double)        \n"
-            "    <argumentList> (float)     multi-value\n"
-            "Parameters:\n"
-            "   -requiredParam=<string>     \n"
-            "   -prmList=<string>           multi-value\n"
-            "   -optionalParam=<string>     optional, default: defaultValue\n"
-            "   -optionalIntParam=<int>     optional\n"
-            "   -optionalParamList=<int>    multi-value, optional, default: {99, 100}\n"
-            "Flags:\n"
-            "  --flg                        \n"
-            "  --help                       show usage info and exit\n"
-            "Commands:\n"
-            "    nested [options]           \n\n"
-    };
-    EXPECT_EQ(reader.exec<FullConfigWithCommand>({"subcommand", "--help"}, [](const auto&) { return 0; }), 0);
+    auto expectedDetailedInfo = std::string{"Usage: testproc subcommand [commands] <argument> -requiredParam=<string> "
+                                            "-prmList=<string>... [params] [flags] <argumentList...>\n"
+                                            "Arguments:\n"
+                                            "    <argument> (double)        \n"
+                                            "    <argumentList> (float)     multi-value\n"
+                                            "Parameters:\n"
+                                            "   -requiredParam=<string>     \n"
+                                            "   -prmList=<string>           multi-value\n"
+                                            "   -optionalParam=<string>     optional, default: defaultValue\n"
+                                            "   -optionalIntParam=<int>     optional\n"
+                                            "   -optionalParamList=<int>    multi-value, optional, default: {99, 100}\n"
+                                            "Flags:\n"
+                                            "  --flg                        \n"
+                                            "  --help                       show usage info and exit\n"
+                                            "Commands:\n"
+                                            "    nested [options]           \n\n"};
+    EXPECT_EQ(
+            reader.exec<FullConfigWithCommand>(
+                    {"subcommand", "--help"},
+                    [](const auto&)
+                    {
+                        return 0;
+                    }),
+            0);
     EXPECT_EQ(output.str(), expectedDetailedInfo);
 }
 
@@ -947,27 +1178,33 @@ TEST(SimpleConfig, ExecCommandHelpUsageInfoFormat)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc", {}, format};
     auto output = std::stringstream{};
     reader.setOutputStream(output);
-    EXPECT_EQ(reader.exec<FullConfigWithCommand>({"subcommand", "--help"}, [](const auto&) { return 0; }), 0);
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc subcommand [commands] <argument> -requiredParam=<string> -prmList=<string>... [params] [flags] <argumentList...>\n"
-            "Arguments:\n"
-            "<argument> (double)       \n"
-            "<argumentList> (float)    multi-value\n"
-            "Parameters:\n"
-            "-requiredParam=<string>   \n"
-            "-prmList=<string>         multi-value\n"
-            "-optionalParam=<string>   optional, default: \n"
-            "                            defaultValue\n"
-            "-optionalIntParam=<int>   optional\n"
-            "-optionalParamList=<int>  multi-value, optional,\n"
-            "                            default: {99, 100}\n"
-            "Flags:\n"
-            "--flg                     \n"
-            "--help                    show usage info and \n"
-            "                            exit\n"
-            "Commands:\n"
-            "nested [options]          \n\n"
-    };
+    EXPECT_EQ(
+            reader.exec<FullConfigWithCommand>(
+                    {"subcommand", "--help"},
+                    [](const auto&)
+                    {
+                        return 0;
+                    }),
+            0);
+    auto expectedDetailedInfo = std::string{"Usage: testproc subcommand [commands] <argument> -requiredParam=<string> "
+                                            "-prmList=<string>... [params] [flags] <argumentList...>\n"
+                                            "Arguments:\n"
+                                            "<argument> (double)       \n"
+                                            "<argumentList> (float)    multi-value\n"
+                                            "Parameters:\n"
+                                            "-requiredParam=<string>   \n"
+                                            "-prmList=<string>         multi-value\n"
+                                            "-optionalParam=<string>   optional, default: \n"
+                                            "                            defaultValue\n"
+                                            "-optionalIntParam=<int>   optional\n"
+                                            "-optionalParamList=<int>  multi-value, optional,\n"
+                                            "                            default: {99, 100}\n"
+                                            "Flags:\n"
+                                            "--flg                     \n"
+                                            "--help                    show usage info and \n"
+                                            "                            exit\n"
+                                            "Commands:\n"
+                                            "nested [options]          \n\n"};
     EXPECT_EQ(output.str(), expectedDetailedInfo);
 }
 
@@ -977,15 +1214,19 @@ TEST(SimpleConfig, ExecNestedCommandHelp)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc"};
     auto output = std::stringstream{};
     reader.setOutputStream(output);
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc subcommand nested -prm=<string> [flags] \n"
-            "Parameters:\n"
-            "   -prm=<string>     \n"
-            "Flags:\n"
-            "  --help             show usage info and exit\n\n"
-    };
-    EXPECT_EQ(reader.exec<FullConfigWithCommand>({"subcommand", "nested", "--help"}, [](const auto&) { return 0; }),
-              0);
+    auto expectedDetailedInfo = std::string{"Usage: testproc subcommand nested -prm=<string> [flags] \n"
+                                            "Parameters:\n"
+                                            "   -prm=<string>     \n"
+                                            "Flags:\n"
+                                            "  --help             show usage info and exit\n\n"};
+    EXPECT_EQ(
+            reader.exec<FullConfigWithCommand>(
+                    {"subcommand", "nested", "--help"},
+                    [](const auto&)
+                    {
+                        return 0;
+                    }),
+            0);
     EXPECT_EQ(output.str(), expectedDetailedInfo);
 }
 
@@ -999,24 +1240,43 @@ TEST(SimpleConfig, ExecNestedCommandHelpUsageInfoFormat)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc", {}, format};
     auto output = std::stringstream{};
     reader.setOutputStream(output);
-    auto expectedDetailedInfo = std::string{
-            "Usage: testproc subcommand nested -prm=<string> [flags] \n"
-            "Parameters:\n"
-            "-prm=<string>   \n"
-            "Flags:\n"
-            "--help          show usage info and exit\n\n"
-    };
-    EXPECT_EQ(reader.exec<FullConfigWithCommand>({"subcommand", "nested", "--help"}, [](const auto&) { return 0; }),
-              0);
+    auto expectedDetailedInfo = std::string{"Usage: testproc subcommand nested -prm=<string> [flags] \n"
+                                            "Parameters:\n"
+                                            "-prm=<string>   \n"
+                                            "Flags:\n"
+                                            "--help          show usage info and exit\n\n"};
+    EXPECT_EQ(
+            reader.exec<FullConfigWithCommand>(
+                    {"subcommand", "nested", "--help"},
+                    [](const auto&)
+                    {
+                        return 0;
+                    }),
+            0);
     EXPECT_EQ(output.str(), expectedDetailedInfo);
 }
 
 TEST(SimpleConfig, ExecSuccess)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc"};
-    EXPECT_EQ(reader.exec<FullConfig>(
-            {"-requiredParam=FOO", "-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero", "-prmList=one",
-             "-optionalParamList=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"}, [](const auto&) { return 0; }), 0);
+    EXPECT_EQ(
+            reader.exec<FullConfig>(
+                    {"-requiredParam=FOO",
+                     "-optionalParam=BAR",
+                     "-optionalIntParam=9",
+                     "-prmList=zero",
+                     "-prmList=one",
+                     "-optionalParamList=1,2",
+                     "--flg",
+                     "4.2",
+                     "1.1",
+                     "2.2",
+                     "3.3"},
+                    [](const auto&)
+                    {
+                        return 0;
+                    }),
+            0);
 }
 
 TEST(SimpleConfig, ExecError)
@@ -1024,10 +1284,24 @@ TEST(SimpleConfig, ExecError)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::Simple>{"testproc"};
     auto errorOutput = std::stringstream{};
     reader.setErrorOutputStream(errorOutput);
-    EXPECT_EQ(reader.exec<FullConfig>({"-optionalParam=BAR", "-optionalIntParam=9", "-prmList=zero", "-prmList=one",
-                                          "-optionalParamList=1,2", "--flg", "4.2", "1.1", "2.2", "3.3"},
-                                         [](const auto&) { return 0; }), -1);
+    EXPECT_EQ(
+            reader.exec<FullConfig>(
+                    {"-optionalParam=BAR",
+                     "-optionalIntParam=9",
+                     "-prmList=zero",
+                     "-prmList=one",
+                     "-optionalParamList=1,2",
+                     "--flg",
+                     "4.2",
+                     "1.1",
+                     "2.2",
+                     "3.3"},
+                    [](const auto&)
+                    {
+                        return 0;
+                    }),
+            -1);
     EXPECT_EQ(errorOutput.str(), "Parameter '-requiredParam' is missing.\n");
 }
 
-}
+} //namespace test_simple_format

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -1,19 +1,20 @@
-#include <gtest/gtest.h>
-#include <cmdlime/config.h>
-#include <cmdlime/commandlinereader.h>
 #include "assert_exception.h"
+#include <cmdlime/commandlinereader.h>
+#include <cmdlime/config.h>
+#include <gtest/gtest.h>
 #include <optional>
 
-namespace test_validator{
+namespace test_validator {
 
 using namespace cmdlime;
 
-struct EnsureNotShorterThan{
+struct EnsureNotShorterThan {
     EnsureNotShorterThan(int size)
-            : minSize_(size)
-    {}
+        : minSize_(size)
+    {
+    }
 
-    template <typename T>
+    template<typename T>
     void operator()(const T& val)
     {
         if (static_cast<int>(val.size()) < minSize_)
@@ -24,8 +25,8 @@ private:
     int minSize_;
 };
 
-struct EnsurePositive{
-    template <typename T>
+struct EnsurePositive {
+    template<typename T>
     void operator()(const T& val)
     {
         if (val < 0)
@@ -33,82 +34,101 @@ struct EnsurePositive{
     }
 };
 
-struct NestedSubcommandConfig: public Config{
+struct NestedSubcommandConfig : public Config {
     CMDLIME_PARAM(prm, std::string) << EnsureNotShorterThan{2};
 };
 
-struct SubcommandConfig: public Config{
+struct SubcommandConfig : public Config {
     CMDLIME_PARAM(requiredParam, std::string) << EnsureNotShorterThan{2};
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue") << EnsureNotShorterThan{2};
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::ShortName("i") << EnsurePositive{};
     CMDLIME_PARAMLIST(prmList, std::vector<std::string>) << cmdlime::ShortName("L") << EnsureNotShorterThan{2};
-    CMDLIME_PARAMLIST(optionalParamList, std::vector<int>)(std::vector<int>{99, 100}) << cmdlime::ShortName("O") << EnsureNotShorterThan{2};
+    CMDLIME_PARAMLIST(optionalParamList, std::vector<int>)
+    (std::vector<int>{99, 100}) << cmdlime::ShortName("O") << EnsureNotShorterThan{2};
     CMDLIME_FLAG(flg);
     CMDLIME_EXITFLAG(exitFlg);
     CMDLIME_ARG(argument, double) << EnsurePositive{};
     CMDLIME_ARGLIST(argumentList, std::vector<float>) << EnsureNotShorterThan{2};
-    CMDLIME_COMMAND(nested, NestedSubcommandConfig)
-        << [](auto& command) {
-            if (command && command->prm.size() >= 5)
-                throw cmdlime::ValidationError{"command param must have a length shorter than 5."};
-        };
+    CMDLIME_COMMAND(nested, NestedSubcommandConfig) << [](auto& command)
+    {
+        if (command && command->prm.size() >= 5)
+            throw cmdlime::ValidationError{"command param must have a length shorter than 5."};
+    };
 };
 
-
-struct FullConfig : public Config{
-    CMDLIME_PARAM(requiredParam, std::string)
-    << [](auto param) {
+struct FullConfig : public Config {
+    CMDLIME_PARAM(requiredParam, std::string) << [](auto param)
+    {
         if (param.size() < 2)
             throw cmdlime::ValidationError{"length can't be less than 2."};
     };
-    CMDLIME_PARAM(optionalParam, std::string)("defaultValue")
-    << [](auto param) {
+    CMDLIME_PARAM(optionalParam, std::string)
+    ("defaultValue") << [](auto param)
+    {
         if (param.size() < 2)
             throw cmdlime::ValidationError{"length can't be less than 2."};
     };
-    CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::ShortName("i")
-        << [](auto param) {
-            if (param && param < 0)
-                throw cmdlime::ValidationError{"value can't be negative."};
-        };
+    CMDLIME_PARAM(optionalIntParam, std::optional<int>)
+    () << cmdlime::ShortName("i")
+       << [](auto param)
+    {
+        if (param && param < 0)
+            throw cmdlime::ValidationError{"value can't be negative."};
+    };
 
     CMDLIME_PARAMLIST(prmList, std::vector<std::string>) << cmdlime::ShortName("L")
-        << [](auto param) {
-            if (param.size() < 2)
-                throw cmdlime::ValidationError{"size can't be less than 2."};
-        };
-    CMDLIME_PARAMLIST(optionalParamList, std::vector<int>)(std::vector<int>{99, 100}) << cmdlime::ShortName("O")
-            << [](auto param) {
-                if (param.size() < 2)
-                    throw cmdlime::ValidationError{"size can't be less than 2."};
-            };
-    CMDLIME_ARG(argument, double)
-        << [](auto param) {
-            if (param < 0)
-                throw cmdlime::ValidationError{"value can't be negative."};
-        };
-    CMDLIME_ARGLIST(argumentList, std::vector<float>)
-        << [](auto param) {
-            if (param.size() < 2)
-                throw cmdlime::ValidationError{"size can't be less than 2."};
-        };
-    CMDLIME_COMMAND(cmd, SubcommandConfig)
-        << [](auto& command){
-            if (command && command->requiredParam.size() >= 5)
-                throw cmdlime::ValidationError{"command required param must have a length shorter than 5."};
-        };
-    CMDLIME_SUBCOMMAND(subcommand, SubcommandConfig)
-        << [](auto& command) {
-            if (command && command->requiredParam.size() >= 5)
-                throw cmdlime::ValidationError{"command required param must have a length shorter than 5."};
-        };
+                                                         << [](auto param)
+    {
+        if (param.size() < 2)
+            throw cmdlime::ValidationError{"size can't be less than 2."};
+    };
+    CMDLIME_PARAMLIST(optionalParamList, std::vector<int>)
+    (std::vector<int>{99, 100}) << cmdlime::ShortName("O")
+                                << [](auto param)
+    {
+        if (param.size() < 2)
+            throw cmdlime::ValidationError{"size can't be less than 2."};
+    };
+    CMDLIME_ARG(argument, double) << [](auto param)
+    {
+        if (param < 0)
+            throw cmdlime::ValidationError{"value can't be negative."};
+    };
+    CMDLIME_ARGLIST(argumentList, std::vector<float>) << [](auto param)
+    {
+        if (param.size() < 2)
+            throw cmdlime::ValidationError{"size can't be less than 2."};
+    };
+    CMDLIME_COMMAND(cmd, SubcommandConfig) << [](auto& command)
+    {
+        if (command && command->requiredParam.size() >= 5)
+            throw cmdlime::ValidationError{"command required param must have a length shorter than 5."};
+    };
+    CMDLIME_SUBCOMMAND(subcommand, SubcommandConfig) << [](auto& command)
+    {
+        if (command && command->requiredParam.size() >= 5)
+            throw cmdlime::ValidationError{"command required param must have a length shorter than 5."};
+    };
 };
 
 TEST(TestValidator, AllSet)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
-    auto cfg = reader.read<FullConfig>({"-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                                           "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});
+    auto cfg = reader.read<FullConfig>(
+            {"-r",
+             "FOO",
+             "-oBAR",
+             "--optional-int-param",
+             "9",
+             "-L",
+             "zero",
+             "-L",
+             "one",
+             "--optional-param-list=1,2",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.optionalIntParam, 9);
@@ -124,11 +144,29 @@ TEST(TestValidator, InvalidParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
-                reader.read<FullConfig>({"-r", "F", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                                            "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter 'required-param' is invalid: length can't be less than 2."});
+            [&]
+            {
+                reader.read<FullConfig>(
+                        {"-r",
+                         "F",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter 'required-param' is invalid: length can't be less than 2."});
             });
 }
 
@@ -136,11 +174,29 @@ TEST(TestValidator, InvalidOptionalParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
-                reader.read<FullConfig>({"-r", "FOO", "-oB", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                                            "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter 'optional-param' is invalid: length can't be less than 2."});
+            [&]
+            {
+                reader.read<FullConfig>(
+                        {"-r",
+                         "FOO",
+                         "-oB",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter 'optional-param' is invalid: length can't be less than 2."});
             });
 }
 
@@ -148,12 +204,29 @@ TEST(TestValidator, InvalidOptionalIntParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-r", "FOO", "-oBAR", "--optional-int-param", "-9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter 'optional-int-param' is invalid: value can't be negative."});
+                        {"-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "-9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter 'optional-int-param' is invalid: value can't be negative."});
             });
 }
 
@@ -161,11 +234,27 @@ TEST(TestValidator, InvalidParamList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
-                reader.read<FullConfig>({"-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero",
-                                            "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter list 'prm-list' is invalid: size can't be less than 2."});
+            [&]
+            {
+                reader.read<FullConfig>(
+                        {"-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter list 'prm-list' is invalid: size can't be less than 2."});
             });
 }
 
@@ -173,12 +262,29 @@ TEST(TestValidator, InvalidOptionalParamList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter list 'optional-param-list' is invalid: size can't be less than 2."});
+                        {"-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter list 'optional-param-list' is invalid: size can't be less than 2."});
             });
 }
 
@@ -186,12 +292,29 @@ TEST(TestValidator, InvalidArg)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "-4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' is invalid: value can't be negative."});
+                        {"-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "-4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Argument 'argument' is invalid: value can't be negative."});
             });
 }
 
@@ -199,12 +322,27 @@ TEST(TestValidator, InvalidArgList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "4.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'argument-list' is invalid: size can't be less than 2."});
+                        {"-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Argument list 'argument-list' is invalid: size can't be less than 2."});
             });
 }
 
@@ -212,12 +350,31 @@ TEST(TestValidator, InvalidCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"cmd", "-r", "F00BAR", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd' is invalid: command required param must have a length shorter than 5."});
+                        {"cmd",
+                         "-r",
+                         "F00BAR",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{
+                                "Command 'cmd' is invalid: command required param must have a length shorter than 5."});
             });
 }
 
@@ -233,12 +390,31 @@ TEST(TestValidator, InvalidCommandParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"cmd", "-r", "F", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's parameter 'required-param' is invalid: size can't be less than 2."});
+                        {"cmd",
+                         "-r",
+                         "F",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{
+                                "Command 'cmd's parameter 'required-param' is invalid: size can't be less than 2."});
             });
 }
 
@@ -246,12 +422,31 @@ TEST(TestValidator, InvalidCommandOptionalParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"cmd", "-r", "FOO", "-oB", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's parameter 'optional-param' is invalid: size can't be less than 2."});
+                        {"cmd",
+                         "-r",
+                         "FOO",
+                         "-oB",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{
+                                "Command 'cmd's parameter 'optional-param' is invalid: size can't be less than 2."});
             });
 }
 
@@ -259,12 +454,31 @@ TEST(TestValidator, InvalidCommandOptionalIntParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"cmd", "-r", "FOO", "-oBAR", "--optional-int-param", "-9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's parameter 'optional-int-param' is invalid: value can't be negative."});
+                        {"cmd",
+                         "-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "-9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{
+                                "Command 'cmd's parameter 'optional-int-param' is invalid: value can't be negative."});
             });
 }
 
@@ -272,11 +486,28 @@ TEST(TestValidator, InvalidCommandParamList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
-                reader.read<FullConfig>({"cmd", "-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero",
-                                            "--optional-param-list=1,2", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's parameter list 'prm-list' is invalid: size can't be less than 2."});
+            [&]
+            {
+                reader.read<FullConfig>(
+                        {"cmd",
+                         "-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Command 'cmd's parameter list 'prm-list' is invalid: size can't be less than 2."});
             });
 }
 
@@ -284,12 +515,31 @@ TEST(TestValidator, InvalidCommandOptionalParamList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"cmd", "-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1", "4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's parameter list 'optional-param-list' is invalid: size can't be less than 2."});
+                        {"cmd",
+                         "-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Command 'cmd's parameter list 'optional-param-list' is invalid: size can't be "
+                                    "less than 2."});
             });
 }
 
@@ -297,12 +547,30 @@ TEST(TestValidator, InvalidCommandArg)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"cmd", "-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "-4.2", "1.1", "2.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's argument 'argument' is invalid: value can't be negative."});
+                        {"cmd",
+                         "-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "-4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Command 'cmd's argument 'argument' is invalid: value can't be negative."});
             });
 }
 
@@ -310,12 +578,29 @@ TEST(TestValidator, InvalidCommandArgList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{
+            [&]
+            {
                 reader.read<FullConfig>(
-                        {"cmd", "-r", "FOO", "-oBAR", "--optional-int-param", "9", "-L", "zero", "-L", "one",
-                         "--optional-param-list=1,2", "4.2", "3.3"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's argument list 'argument-list' is invalid: size can't be less than 2."});
+                        {"cmd",
+                         "-r",
+                         "FOO",
+                         "-oBAR",
+                         "--optional-int-param",
+                         "9",
+                         "-L",
+                         "zero",
+                         "-L",
+                         "one",
+                         "--optional-param-list=1,2",
+                         "4.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{
+                                "Command 'cmd's argument list 'argument-list' is invalid: size can't be less than 2."});
             });
 }
 
@@ -323,9 +608,16 @@ TEST(TestValidator, InvalidNestedCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{ reader.read<FullConfig>({"cmd", "nested", "--prm", "F00BAR"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'cmd's command 'nested' is invalid: command param must have a length shorter than 5."});
+            [&]
+            {
+                reader.read<FullConfig>({"cmd", "nested", "--prm", "F00BAR"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Command 'cmd's command 'nested' is invalid: command param must have a length "
+                                    "shorter than 5."});
             });
 }
 
@@ -333,10 +625,16 @@ TEST(TestValidator, InvalidNestedCommandParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::GNU>{};
     assert_exception<cmdlime::ParsingError>(
-            [&]{ reader.read<FullConfig>({"cmd", "nested", "--prm", "F"});},
-            [](const cmdlime::ParsingError& error){
-                EXPECT_EQ(std::string{error.what()}, std::string{"Command 'nested's parameter 'prm' is invalid: size can't be less than 2."});
+            [&]
+            {
+                reader.read<FullConfig>({"cmd", "nested", "--prm", "F"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Command 'nested's parameter 'prm' is invalid: size can't be less than 2."});
             });
 }
 
-}
+} //namespace test_validator

--- a/tests/test_x11_format.cpp
+++ b/tests/test_x11_format.cpp
@@ -1,18 +1,18 @@
-#include <gtest/gtest.h>
-#include <cmdlime/config.h>
-#include <cmdlime/commandlinereader.h>
 #include "assert_exception.h"
+#include <cmdlime/commandlinereader.h>
+#include <cmdlime/config.h>
+#include <gtest/gtest.h>
 #include <optional>
 
-namespace text_x11_format{
+namespace text_x11_format {
 
 using namespace cmdlime;
 
-struct NestedSubcommandConfig: public Config{
+struct NestedSubcommandConfig : public Config {
     CMDLIME_PARAM(prm, std::string);
 };
 
-struct SubcommandConfig: public Config{
+struct SubcommandConfig : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)();
@@ -24,7 +24,7 @@ struct SubcommandConfig: public Config{
     CMDLIME_COMMAND(nested, NestedSubcommandConfig);
 };
 
-struct FullConfig : public Config{
+struct FullConfig : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)();
@@ -36,7 +36,7 @@ struct FullConfig : public Config{
     CMDLIME_SUBCOMMAND(subcommand, SubcommandConfig);
 };
 
-struct FullConfigWithCommand : public Config{
+struct FullConfigWithCommand : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)();
@@ -52,9 +52,23 @@ TEST(X11Config, AllSet)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<FullConfig>(
-            {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "-9", "-prmlist", "zero",
-             "-prmlist", "one",
-             "-optionalparamlist", "1,2", "-flg", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredparam",
+             "FOO",
+             "-optionalparam",
+             "BAR",
+             "-optionalintparam",
+             "-9",
+             "-prmlist",
+             "zero",
+             "-prmlist",
+             "one",
+             "-optionalparamlist",
+             "1,2",
+             "-flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.optionalIntParam, -9);
@@ -70,10 +84,32 @@ TEST(X11Config, AllSetInSubCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<FullConfig>(
-            {"-requiredparam", "FOO", "-prmlist", "zero", "-prmlist", "one", "4.2", "1.1",
-             "subcommand", "-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist",
-             "zero", "-prmlist", "one",
-             "-optionalparamlist", "1,2", "-flg", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredparam",
+             "FOO",
+             "-prmlist",
+             "zero",
+             "-prmlist",
+             "one",
+             "4.2",
+             "1.1",
+             "subcommand",
+             "-requiredparam",
+             "FOO",
+             "-optionalparam",
+             "BAR",
+             "-optionalintparam",
+             "9",
+             "-prmlist",
+             "zero",
+             "-prmlist",
+             "one",
+             "-optionalparamlist",
+             "1,2",
+             "-flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
@@ -101,7 +137,7 @@ TEST(X11Config, MissingOptionals)
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_EQ(cfg.optionalIntParam.has_value(), false);
     EXPECT_EQ(cfg.prmList, (std::vector<std::string>{"zero"}));
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 4.2);
     EXPECT_EQ(cfg.argumentList, (std::vector<float>{1.1f, 2.2f, 3.3f}));
@@ -111,28 +147,69 @@ TEST(X11Config, MissingParamAllSetInSubCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"subcommand", "-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist",
-                 "zero", "-prmlist", "one",
-                 "-optionalparamlist", "1,2", "-flg", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-requiredparam' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"subcommand",
+                         "-requiredparam",
+                         "FOO",
+                         "-optionalparam",
+                         "BAR",
+                         "-optionalintparam",
+                         "9",
+                         "-prmlist",
+                         "zero",
+                         "-prmlist",
+                         "one",
+                         "-optionalparamlist",
+                         "1,2",
+                         "-flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-requiredparam' is missing."});
+            });
 }
 
 TEST(X11Config, AllSetInCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<FullConfigWithCommand>(
-            {"-requiredparam", "FOO", "-prmlist", "zero", "-prmlist", "one", "4.2", "1.1",
-             "subcommand", "-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist",
-             "zero", "-prmlist", "one",
-             "-optionalparamlist", "1,2", "-flg", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredparam",
+             "FOO",
+             "-prmlist",
+             "zero",
+             "-prmlist",
+             "one",
+             "4.2",
+             "1.1",
+             "subcommand",
+             "-requiredparam",
+             "FOO",
+             "-optionalparam",
+             "BAR",
+             "-optionalintparam",
+             "9",
+             "-prmlist",
+             "zero",
+             "-prmlist",
+             "one",
+             "-optionalparamlist",
+             "1,2",
+             "-flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_TRUE(cfg.requiredParam.empty());
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -151,14 +228,29 @@ TEST(X11Config, MissingParamAllSetInCommand)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<FullConfigWithCommand>(
-            {"subcommand", "-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist",
-             "zero", "-prmlist", "one",
-             "-optionalparamlist", "1,2", "-flg", "4.2", "1.1", "2.2", "3.3"});
+            {"subcommand",
+             "-requiredparam",
+             "FOO",
+             "-optionalparam",
+             "BAR",
+             "-optionalintparam",
+             "9",
+             "-prmlist",
+             "zero",
+             "-prmlist",
+             "one",
+             "-optionalparamlist",
+             "1,2",
+             "-flg",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_TRUE(cfg.requiredParam.empty());
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -181,7 +273,7 @@ TEST(X11Config, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.optionalIntParam.has_value());
     EXPECT_TRUE(cfg.prmList.empty());
-    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.flg, false);
     EXPECT_EQ(cfg.argument, 0.f);
     EXPECT_TRUE(cfg.argumentList.empty());
@@ -190,7 +282,7 @@ TEST(X11Config, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.subcommand->optionalParam, std::string{"defaultValue"});
     EXPECT_FALSE(cfg.subcommand->optionalIntParam.has_value());
     EXPECT_TRUE(cfg.subcommand->prmList.empty());
-    EXPECT_EQ(cfg.subcommand->optionalParamList, (std::vector<int>{99,100}));
+    EXPECT_EQ(cfg.subcommand->optionalParamList, (std::vector<int>{99, 100}));
     EXPECT_EQ(cfg.subcommand->flg, false);
     EXPECT_EQ(cfg.subcommand->argument, 0.f);
     EXPECT_TRUE(cfg.subcommand->argumentList.empty());
@@ -198,7 +290,7 @@ TEST(X11Config, MissingParamAllSetInNestedCommand)
     EXPECT_EQ(cfg.subcommand->nested->prm, "FOO");
 }
 
-struct FullConfigWithOptionalArgList : public Config{
+struct FullConfigWithOptionalArgList : public Config {
     CMDLIME_PARAM(requiredParam, std::string);
     CMDLIME_PARAM(optionalParam, std::string)({"defaultValue"});
     CMDLIME_PARAM(optionalIntParam, std::optional<int>)();
@@ -223,214 +315,362 @@ TEST(X11Config, MissingParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-optionalparam", "FOO", "-prmlist", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-requiredparam' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-optionalparam", "FOO", "-prmlist", "zero", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-requiredparam' is missing."});
+            });
 }
 
 TEST(X11Config, MissingArg)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfigWithOptionalArgList>(
-                {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-flg"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'argument' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfigWithOptionalArgList>(
+                        {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-flg"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'argument' is missing."});
+            });
 }
 
 TEST(X11Config, MissingArgList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist", "zero",
-                 "-flg", "4.2"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'argumentlist' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam",
+                         "FOO",
+                         "-optionalparam",
+                         "BAR",
+                         "-optionalintparam",
+                         "9",
+                         "-prmlist",
+                         "zero",
+                         "-flg",
+                         "4.2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'argumentlist' is missing."});
+            });
 }
 
 TEST(X11Config, MissingParamList)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-flg", "4.2", "1.1",
-                 "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-prmlist' is missing."});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam",
+                         "FOO",
+                         "-optionalparam",
+                         "BAR",
+                         "-optionalintparam",
+                         "9",
+                         "-flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-prmlist' is missing."});
+            });
 }
 
 TEST(X11Config, UnexpectedParam)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-testparam", "TEST", "-prmlist", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-testparam'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam",
+                         "FOO",
+                         "-testparam",
+                         "TEST",
+                         "-prmlist",
+                         "zero",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-testparam'"});
+            });
 }
 
 TEST(X11Config, UnexpectedFlag)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-testflag", "-prmlist", "zero", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-testflag'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam", "FOO", "-testflag", "-prmlist", "zero", "4.2", "1.1", "2.2", "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown parameter or flag '-testflag'"});
+            });
 }
 
 TEST(X11Config, UnexpectedArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-prm", "FOO", "4.2", "1"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '4.2'"});
-        });
-
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-prm", "FOO", "4.2", "1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '4.2'"});
+            });
 }
 
 TEST(X11Config, WrongParamType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "nine", "-prmlist", "zero",
-                 "-flg", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '-optionalintparam' value from 'nine'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam",
+                         "FOO",
+                         "-optionalparam",
+                         "BAR",
+                         "-optionalintparam",
+                         "nine",
+                         "-prmlist",
+                         "zero",
+                         "-flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set parameter '-optionalintparam' value from 'nine'"});
+            });
 }
 
 TEST(X11Config, WrongParamListElementType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-optionalparam", "BAR", "-prmlist", "zero", "-optionalparamlist",
-                 "not-int", "-flg", "4.2", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set parameter '-optionalparamlist' value from 'not-int'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam",
+                         "FOO",
+                         "-optionalparam",
+                         "BAR",
+                         "-prmlist",
+                         "zero",
+                         "-optionalparamlist",
+                         "not-int",
+                         "-flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set parameter '-optionalparamlist' value from 'not-int'"});
+            });
 }
 
 TEST(X11Config, WrongArgType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist", "zero",
-                 "-flg", "fortytwo", "1.1", "2.2", "3.3"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam",
+                         "FOO",
+                         "-optionalparam",
+                         "BAR",
+                         "-optionalintparam",
+                         "9",
+                         "-prmlist",
+                         "zero",
+                         "-flg",
+                         "fortytwo",
+                         "1.1",
+                         "2.2",
+                         "3.3"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument 'argument' value from 'fortytwo'"});
+            });
 }
 
 TEST(X11Config, WrongArgListElementType)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<FullConfig>(
-                {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist", "zero",
-                 "-flg", "4.2", "1.1", "2.2", "three"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Couldn't set argument list 'argumentlist' element's value from 'three'"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<FullConfig>(
+                        {"-requiredparam",
+                         "FOO",
+                         "-optionalparam",
+                         "BAR",
+                         "-optionalintparam",
+                         "9",
+                         "-prmlist",
+                         "zero",
+                         "-flg",
+                         "4.2",
+                         "1.1",
+                         "2.2",
+                         "three"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Couldn't set argument list 'argumentlist' element's value from 'three'"});
+            });
 }
 
 TEST(X11Config, ParamWrongNameNonAlphaFirstChar)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::Name("!param");
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-param", "name"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name '!param' must start with an alphabet character"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-param", "name"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name '!param' must start with an alphabet character"});
+            });
 }
 
 TEST(X11Config, ParamWrongNameNonAlphanum)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::Name("p$r$m");
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{auto cfg = reader.read<Cfg>({"-param", "name"});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'p$r$m' must consist of alphanumeric characters and hyphens"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-param", "name"});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(
+                        std::string{error.what()},
+                        std::string{"Parameter's name 'p$r$m' must consist of alphanumeric characters and hyphens"});
+            });
 }
 
 TEST(X11Config, ParamEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-prm"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-prm' value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-prm"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-prm' value can't be empty"});
+            });
 }
 
 TEST(X11Config, ParamListEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAMLIST(params, std::vector<std::string>);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"-params", ""});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-params' value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"-params", ""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-params' value can't be empty"});
+            });
 }
 
 TEST(X11Config, ArgEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARG(argument, std::string);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({""});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Argument 'argument' value can't be empty"});
+            });
 }
 
 TEST(X11Config, ArgListEmptyValue)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARGLIST(args, std::vector<std::string>);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{auto cfg = reader.read<Cfg>({"foo", ""});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'args' element value can't be empty"});
-        });
+            [&]
+            {
+                auto cfg = reader.read<Cfg>({"foo", ""});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Argument list 'args' element value can't be empty"});
+            });
 }
-
 
 TEST(X11Config, ValuesWithWhitespace)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, std::string);
         CMDLIME_PARAMLIST(prmList, std::vector<std::string>);
         CMDLIME_ARG(argument, std::string);
@@ -446,7 +686,7 @@ TEST(X11Config, ValuesWithWhitespace)
 
 TEST(X11Config, NegativeNumberToArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_ARG(argument, int);
         CMDLIME_ARG(argumentStr, std::string);
         CMDLIME_ARGLIST(argumentList, std::vector<double>);
@@ -460,20 +700,24 @@ TEST(X11Config, NegativeNumberToArg)
 
 TEST(X11Config, NegativeNumberWithoutArg)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, int);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<Cfg>({"-2"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '-2'"});
-        });
+            [&]
+            {
+                reader.read<Cfg>({"-2"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Encountered unknown positional argument '-2'"});
+            });
 }
 
 TEST(X11Config, ArgsDelimiter)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(prm, int);
         CMDLIME_PARAM(optionalParam, int)(0);
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
@@ -488,7 +732,7 @@ TEST(X11Config, ArgsDelimiter)
 
 TEST(X11Config, ArgsDelimiterFront)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(optionalParam, int)(0);
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
     };
@@ -496,12 +740,12 @@ TEST(X11Config, ArgsDelimiterFront)
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<Cfg>({"--", "0", "1", "-optionalparam", "1", "2"});
     EXPECT_EQ(cfg.optionalParam, 0);
-    EXPECT_EQ(cfg.argumentList, (std::vector<std::string>{"0", "1", "-optionalparam","1", "2"}));
+    EXPECT_EQ(cfg.argumentList, (std::vector<std::string>{"0", "1", "-optionalparam", "1", "2"}));
 }
 
 TEST(X11Config, ArgsDelimiterBack)
 {
-    struct Cfg : public Config{
+    struct Cfg : public Config {
         CMDLIME_PARAM(optionalParam, int)(0);
         CMDLIME_ARGLIST(argumentList, std::vector<std::string>);
     };
@@ -514,7 +758,7 @@ TEST(X11Config, ArgsDelimiterBack)
 
 TEST(X11Config, PascalNames)
 {
-    struct PascalConfig : public Config{
+    struct PascalConfig : public Config {
         CMDLIME_PARAM(RequiredParam, std::string);
         CMDLIME_PARAM(OptionalParam, std::string)("defaultValue");
         CMDLIME_PARAM(OptionalIntParam, std::optional<int>)();
@@ -526,9 +770,25 @@ TEST(X11Config, PascalNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<PascalConfig>(
-            {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-prmlist", "zero",
-             "-prmlist", "one",
-             "-optionalparamlist", "1", "-optionalparamlist", "2", "-flag", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredparam",
+             "FOO",
+             "-optionalparam",
+             "BAR",
+             "-optionalintparam",
+             "9",
+             "-prmlist",
+             "zero",
+             "-prmlist",
+             "one",
+             "-optionalparamlist",
+             "1",
+             "-optionalparamlist",
+             "2",
+             "-flag",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.RequiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.OptionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.OptionalIntParam, 9);
@@ -541,7 +801,7 @@ TEST(X11Config, PascalNames)
 
 TEST(X11Config, SnakeNames)
 {
-    struct PascalConfig : public Config{
+    struct PascalConfig : public Config {
         CMDLIME_PARAM(required_param, std::string);
         CMDLIME_PARAM(optional_param, std::string)("defaultValue");
         CMDLIME_PARAM(optional_int_param, std::optional<int>)();
@@ -553,9 +813,25 @@ TEST(X11Config, SnakeNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<PascalConfig>(
-            {"-requiredparam", "FOO", "-optionalparam", "BAR", "-optionalintparam", "9", "-paramlist", "zero",
-             "-paramlist", "one",
-             "-optionalparamlist", "1", "-optionalparamlist", "2", "-flag", "4.2", "1.1", "2.2", "3.3"});
+            {"-requiredparam",
+             "FOO",
+             "-optionalparam",
+             "BAR",
+             "-optionalintparam",
+             "9",
+             "-paramlist",
+             "zero",
+             "-paramlist",
+             "one",
+             "-optionalparamlist",
+             "1",
+             "-optionalparamlist",
+             "2",
+             "-flag",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.required_param, std::string{"FOO"});
     EXPECT_EQ(cfg.optional_param, std::string{"BAR"});
     EXPECT_EQ(cfg.optional_int_param, 9);
@@ -568,7 +844,7 @@ TEST(X11Config, SnakeNames)
 
 TEST(X11Config, CustomNames)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(requiredParam, std::string) << cmdlime::Name{"customRequiredParam"};
         CMDLIME_PARAM(optionalParam, std::string)("defaultValue") << cmdlime::Name{"customOptionalParam"};
         CMDLIME_PARAM(optionalIntParam, std::optional<int>)() << cmdlime::Name{"customOptionalIntParam"};
@@ -578,8 +854,17 @@ TEST(X11Config, CustomNames)
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     auto cfg = reader.read<TestConfig>(
-            {"-customRequiredParam", "FOO", "-customOptionalParam", "BAR", "-customOptionalIntParam", "9",
-             "-customFlag", "4.2", "1.1", "2.2", "3.3"});
+            {"-customRequiredParam",
+             "FOO",
+             "-customOptionalParam",
+             "BAR",
+             "-customOptionalIntParam",
+             "9",
+             "-customFlag",
+             "4.2",
+             "1.1",
+             "2.2",
+             "3.3"});
     EXPECT_EQ(cfg.requiredParam, std::string{"FOO"});
     EXPECT_EQ(cfg.optionalParam, std::string{"BAR"});
     EXPECT_EQ(cfg.optionalIntParam, 9);
@@ -590,96 +875,120 @@ TEST(X11Config, CustomNames)
 
 TEST(X11Config, CustomNamesMissingParam)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, double) << cmdlime::Name{"customParam"};
         CMDLIME_PARAMLIST(prmList, std::vector<float>) << cmdlime::Name{"customArgList"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-customParam' is missing."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-customParam' is missing."});
+            });
 }
 
 TEST(X11Config, CustomNamesMissingParamList)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, double) << cmdlime::Name{"customParam"};
         CMDLIME_PARAMLIST(prmList, std::vector<float>) << cmdlime::Name{"customParamList"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<TestConfig>({"-customParam", "1"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-customParamList' is missing."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({"-customParam", "1"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter '-customParamList' is missing."});
+            });
 }
 
 TEST(X11Config, CustomNamesMissingArg)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_ARG(argument, double) << cmdlime::Name{"customArg"};
         CMDLIME_ARGLIST(argumentList, std::vector<float>) << cmdlime::Name{"customArgList"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'customArg' is missing."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Positional argument 'customArg' is missing."});
+            });
 }
 
 TEST(X11Config, CustomNamesMissingArgList)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_ARG(argument, double) << cmdlime::Name{"customArg"};
         CMDLIME_ARGLIST(argumentList, std::vector<float>) << cmdlime::Name{"customArgList"};
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ParsingError>(
-        [&]{ reader.read<TestConfig>({"1.0"});},
-        [](const cmdlime::ParsingError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'customArgList' is missing."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({"1.0"});
+            },
+            [](const cmdlime::ParsingError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Arguments list 'customArgList' is missing."});
+            });
 }
 
 TEST(X11Config, ConfigErrorRepeatingParamNames)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(Prm, double)();
         CMDLIME_PARAM(prm, int)();
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'prm' is already used."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Parameter's name 'prm' is already used."});
+            });
 }
 
 TEST(X11Config, ConfigErrorRepeatingFlagNames)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_FLAG(Flg);
         CMDLIME_FLAG(flg);
     };
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     assert_exception<cmdlime::ConfigError>(
-        [&]{ reader.read<TestConfig>({});},
-        [](const cmdlime::ConfigError& error){
-            EXPECT_EQ(std::string{error.what()}, std::string{"Flag's name 'flg' is already used."});
-        });
+            [&]
+            {
+                reader.read<TestConfig>({});
+            },
+            [](const cmdlime::ConfigError& error)
+            {
+                EXPECT_EQ(std::string{error.what()}, std::string{"Flag's name 'flg' is already used."});
+            });
 }
 
 TEST(X11Config, UsageInfo)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     reader.setProgramName("testproc");
-    auto expectedInfo = std::string{
-    "Usage: testproc [commands] <argument> -requiredparam <string> -prmlist <string>... "
-    "[-optionalparam <string>] [-optionalintparam <int>] [-optionalparamlist <int>...] [-flg] <argumentlist...>\n"
-    };
+    auto expectedInfo =
+            std::string{"Usage: testproc [commands] <argument> -requiredparam <string> -prmlist <string>... "
+                        "[-optionalparam <string>] [-optionalintparam <int>] [-optionalparamlist <int>...] [-flg] "
+                        "<argumentlist...>\n"};
     EXPECT_EQ(reader.usageInfo<FullConfig>(), expectedInfo);
 }
 
@@ -687,27 +996,27 @@ TEST(X11Config, DetailedUsageInfo)
 {
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     reader.setProgramName("testproc");
-    auto expectedDetailedInfo = std::string{
-    "Usage: testproc [commands] <argument> -requiredparam <string> -prmlist <string>... [params] [flags] <argumentlist...>\n"
-    "Arguments:\n"
-    "    <argument> (double)        \n"
-    "    <argumentlist> (float)     multi-value\n"
-    "Parameters:\n"
-    "   -requiredparam <string>     \n"
-    "   -prmlist <string>           multi-value\n"
-    "   -optionalparam <string>     optional, default: defaultValue\n"
-    "   -optionalintparam <int>     optional\n"
-    "   -optionalparamlist <int>    multi-value, optional, default: {99, 100}\n"
-    "Flags:\n"
-    "   -flg                        \n"
-    "Commands:\n"
-    "    subcommand [options]       \n"};
+    auto expectedDetailedInfo = std::string{"Usage: testproc [commands] <argument> -requiredparam <string> -prmlist "
+                                            "<string>... [params] [flags] <argumentlist...>\n"
+                                            "Arguments:\n"
+                                            "    <argument> (double)        \n"
+                                            "    <argumentlist> (float)     multi-value\n"
+                                            "Parameters:\n"
+                                            "   -requiredparam <string>     \n"
+                                            "   -prmlist <string>           multi-value\n"
+                                            "   -optionalparam <string>     optional, default: defaultValue\n"
+                                            "   -optionalintparam <int>     optional\n"
+                                            "   -optionalparamlist <int>    multi-value, optional, default: {99, 100}\n"
+                                            "Flags:\n"
+                                            "   -flg                        \n"
+                                            "Commands:\n"
+                                            "    subcommand [options]       \n"};
     EXPECT_EQ(reader.usageInfoDetailed<FullConfig>(), expectedDetailedInfo);
 }
 
 TEST(X11Config, CustomValueNames)
 {
-    struct TestConfig : public Config{
+    struct TestConfig : public Config {
         CMDLIME_PARAM(prm, std::string) << cmdlime::ValueName{"STRING"};
         CMDLIME_PARAMLIST(prmList, std::vector<int>)() << cmdlime::ValueName{"INTS"};
         CMDLIME_ARG(argument, double) << cmdlime::ValueName{"DOUBLE"};
@@ -716,20 +1025,19 @@ TEST(X11Config, CustomValueNames)
 
     auto reader = cmdlime::CommandLineReader<cmdlime::Format::X11>{};
     reader.setProgramName("testproc");
-    auto expectedInfo = std::string{
-    "Usage: testproc <argument> -prm <STRING> [params] <argumentlist...>\n"
-    "Arguments:\n"
-    "    <argument> (DOUBLE)         \n"
-    "    <argumentlist> (FLOATS)     multi-value\n"
-    "Parameters:\n"
-    "   -prm <STRING>                \n"
-    "   -prmlist <INTS>              multi-value, optional, default: {}\n"
-    };
+    auto expectedInfo = std::string{"Usage: testproc <argument> -prm <STRING> [params] <argumentlist...>\n"
+                                    "Arguments:\n"
+                                    "    <argument> (DOUBLE)         \n"
+                                    "    <argumentlist> (FLOATS)     multi-value\n"
+                                    "Parameters:\n"
+                                    "   -prm <STRING>                \n"
+                                    "   -prmlist <INTS>              multi-value, optional, default: {}\n"};
     EXPECT_EQ(reader.usageInfoDetailed<TestConfig>(), expectedInfo);
 }
 
-TEST(X11Config, WrongParamsWithExitFlag){
-    struct ConfigWithExitFlag : public Config{
+TEST(X11Config, WrongParamsWithExitFlag)
+{
+    struct ConfigWithExitFlag : public Config {
         CMDLIME_PARAM(requiredParam, int);
         CMDLIME_PARAM(optionalParam, std::string)("defaultValue");
         CMDLIME_FLAG(flg);
@@ -742,4 +1050,4 @@ TEST(X11Config, WrongParamsWithExitFlag){
     EXPECT_EQ(cfg.exitFlg, true);
 }
 
-}
+} //namespace text_x11_format


### PR DESCRIPTION
-From now on non-aggregate types can be used with cmdlime (the user must inherit cmdlime::Config constructors with `using Config::Config` decalaration)
-Added clang-format config

Closes #25
