### PR TITLE
Windows UTF16 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,14 @@ if (CMDLIME_USE_NAMEOF)
     SealLake_Bundle(
             NAME nameof
             GIT_REPOSITORY https://github.com/Neargye/nameof.git
-            GIT_TAG        b877a1a
+            GIT_TAG        master
     )
 endif()
 
 SealLake_Bundle(
         NAME cmdlime_sfun
         GIT_REPOSITORY https://github.com/kamchatka-volcano/sfun.git
-        GIT_TAG        v3.1.1
+        GIT_TAG        dev
         DESTINATION include/cmdlime/detail/external
         DIRECTORIES include/sfun
         TEXT_REPLACEMENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ include(GNUInstallDirs)
 include(external/seal_lake)
 
 option(CMDLIME_USE_NAMEOF "Enable automatic registration of struct field names using the nameof library" OFF)
+option(CMDLIME_NO_WINDOWS_UNICODE "Disable storing std::wstring and std::filesystem::path with UTF16 encoding on Windows" OFF)
+
 if (CMDLIME_USE_NAMEOF)
     SealLake_IsInstalled(NAMEOF_OPT_INSTALL)
     SealLake_Bundle(
@@ -41,6 +43,10 @@ if (CMDLIME_USE_NAMEOF)
     SealLake_Dependencies(
             nameof 0.10.2
     )
+endif()
+
+if (CMDLIME_NO_WINDOWS_UNICODE)
+    target_compile_definitions(cmdlime INTERFACE CMDLIME_NO_WINDOWS_UNICODE_SUPPORT)
 endif()
 
 SealLake_OptionalBuildSteps(tests examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.18)
-project(cmdlime VERSION 2.3.1 DESCRIPTION "C++17 command line parsing library")
+project(cmdlime VERSION 2.4.0 DESCRIPTION "C++17 command line parsing library")
 include(GNUInstallDirs)
 include(external/seal_lake)
 

--- a/README.md
+++ b/README.md
@@ -241,12 +241,36 @@ int main(int argc, char** argv)
 ```
 
 Try to run it and...
+
 ```console
 Usage: person-finder <zip-code> --name <string> [--verbose] [--help] [--version]
 Flag's short name 'v' is already used.
 ```
-you'll get this error. The thing is, the default command line format supports short names and our flags `--verbose` and `--version` ended up having the same short name `-v`. Read the next section to learn how to fix it.
 
+you'll get this error. The thing is, the default command line format supports short names and our flags `--verbose`
+and `--version` ended up having the same short name `-v`. Read the next section to learn how to fix it.
+
+### Unicode support
+
+`cmdlime` stores strings in `std::string`, and all operations only require the used encoding to be compatible with
+ASCII. This means that UTF-8 command line arguments are supported by default. On Windows Unicode command line arguments
+encoded with UTF-16 can be automatically converted to UTF-8 with the `CommandLineReader::exec()` overload, which takes a
+wide string array. In this case, the `wmain` entry point function should be used:
+
+```
+int wmain(int argc, wchar_t** argv)
+{
+    auto reader = cmdlime::CommandLineReader{"person-finder"};
+    reader.setVersionInfo("person-finder 1.0");
+    return reader.exec<Cfg>(argc, argv, mainApp);
+}
+```
+
+Additionally, on Windows, `cmdlime` parameters of types `std::wstring` and `std::filesystem::path` are stored with
+UTF-16 encoding by default. This allows using filesystem paths from your cmdlime config structure with `std::fstream`
+and `std::filesystem` functions without any manual conversions. This functionality can be disabled by setting a CMake
+variable `CMDLIME_NO_WINDOWS_UNICODE`, or by manually adding a compiler definition `CMDLIME_NO_WINDOWS_UNICODE_SUPPORT`
+to your target.
 
 ### Custom names
 

--- a/include/cmdlime/config.h
+++ b/include/cmdlime/config.h
@@ -12,6 +12,7 @@
 #include "detail/nameof_import.h"
 #include "detail/paramcreator.h"
 #include "detail/paramlistcreator.h"
+#include "detail/windows_unicode_support.h"
 #include <optional>
 #include <string>
 

--- a/include/cmdlime/detail/windows_unicode_support.h
+++ b/include/cmdlime/detail/windows_unicode_support.h
@@ -1,0 +1,45 @@
+#ifndef CMDLIME_WINDOWS_UNICODE_SUPPORT_H
+#define CMDLIME_WINDOWS_UNICODE_SUPPORT_H
+
+#ifdef _WIN32
+#ifndef CMDLIME_NO_WINDOWS_UNICODE_SUPPORT
+
+#include "external/sfun/path.h"
+#include "external/sfun/wstringconv.h"
+#include <cmdlime/stringconverter.h>
+#include <filesystem>
+#include <string>
+
+namespace cmdlime {
+
+template<>
+struct StringConverter<std::filesystem::path> {
+    static std::optional<std::string> toString(const std::filesystem::path& path)
+    {
+        return sfun::pathString(path);
+    }
+
+    static std::optional<std::filesystem::path> fromString(const std::string& data)
+    {
+        return sfun::makePath(data);
+    }
+};
+
+template<>
+struct StringConverter<std::wstring> {
+    static std::optional<std::string> toString(const std::wstring& str)
+    {
+        return sfun::fromWString(str);
+    }
+
+    static std::optional<std::wstring> fromString(const std::string& data)
+    {
+        return sfun::toWString(data);
+    }
+};
+
+} //namespace cmdlime
+
+#endif
+#endif
+#endif //CMDLIME_WINDOWS_UNICODE_SUPPORT_H


### PR DESCRIPTION
-added CommandLineReader::exec() overloads taking wide string arguments on Windows
-added the support for reading std::wstring and std::filesystem::path with UTF16 encoding on windows 